### PR TITLE
niza/fix-broken-inlines

### DIFF
--- a/src/RequestInsurance/ViewComponents/InlinePrint.php
+++ b/src/RequestInsurance/ViewComponents/InlinePrint.php
@@ -25,7 +25,7 @@ class InlinePrint extends Component
      */
     public function __construct($content)
     {
-        $this->$content = $content;
+        $this->content = $content;
     }
 
     /**


### PR DESCRIPTION
Inline print were broken because of a typo, and now fixed