### PR TITLE
thwo/allow-empty-payload

### DIFF
--- a/publishable/migrations/2021_01_29_121827_set_default_value_for_payload.php
+++ b/publishable/migrations/2021_01_29_121827_set_default_value_for_payload.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndicesRequestInsurance extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('request_insurances', function (Blueprint $table) {
+            $table->longText('payload')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('request_insurance_logs', function (Blueprint $table) {
+            $table->longText('payload')->change();
+        });
+    }
+}

--- a/publishable/migrations/2021_01_29_121827_set_default_value_for_payload_request_insurance.php
+++ b/publishable/migrations/2021_01_29_121827_set_default_value_for_payload_request_insurance.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddIndicesRequestInsurance extends Migration
+class SetDefaultValueForPayloadRequestInsurance extends Migration
 {
     /**
      * Run the migrations.

--- a/publishable/migrations/2021_01_29_121827_set_default_value_for_payload_request_insurance.php
+++ b/publishable/migrations/2021_01_29_121827_set_default_value_for_payload_request_insurance.php
@@ -14,7 +14,7 @@ class SetDefaultValueForPayloadRequestInsurance extends Migration
     public function up(): void
     {
         Schema::table('request_insurances', function (Blueprint $table) {
-            $table->longText('payload')->nullable()->default(null);
+            $table->longText('payload')->nullable()->default(null)->change();
         });
     }
 


### PR DESCRIPTION
Sometimes, we want to create a RI without payload
Note: when changing a column in a Laravel migration, doctrine/dbal is required as a composer package