### PR TITLE
jabj/request-history-migration

### DIFF
--- a/publishable/migrations/2022_06_14_104500_create_request_insurance_history_table.php
+++ b/publishable/migrations/2022_06_14_104500_create_request_insurance_history_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateRequestInsuranceHistoryTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('request_insurance_history', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('old_request_insurance_id');
+            $table->unsignedBigInteger('new_request_insurance_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('request_insurance_history');
+    }
+}


### PR DESCRIPTION
#Trello
https://trello.com/c/nuKwUcd1

#Description
Migration to enable a history of request insurances, so that the old and the new request insurances (from applied edits) can be linked.

#Reason
It should be possible to view the history of the edits.