### PR TITLE
Gusb/catch-inifinitely-processing-requests

### DIFF
--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -55,11 +55,13 @@ class FailOrReadyProcessingRequestInsurances extends Command
         // Get ids of request insurances that have been updated, so they can be included in the log.
         $ids = $reqs->get("id");
 
-        // Update state depending on retries_inconsistent
-        $stateChange = $retries_inconsistent ? State::READY : State::FAILED;
-        $reqs->update(["state" => $stateChange]);
+        if ( ! $ids->isEmpty()) {
+            // Update state depending on retries_inconsistent
+            $stateChange = $retries_inconsistent ? State::READY : State::FAILED;
+            $reqs->update(["state" => $stateChange]);
 
-        $boolString = $retries_inconsistent ? "true" : "false";
-        Log::info(print("Request insurances with ids $ids, with retry_inconsistent = $boolString, were set to state $stateChange, due to processing for too long."));
+            $boolString = $retries_inconsistent ? "true" : "false";
+            Log::info(print("Request insurances with ids $ids, with retry_inconsistent = $boolString, were set to state $stateChange, due to processing for too long."));
+        }
     }
 }

--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -16,7 +16,7 @@ class FailOrReadyProcessingRequestInsurances extends Command
      *
      * @var string
      */
-    protected $signature = 'unstuck-processing:request-insurances';
+    protected $signature = 'request-insurance:unstuck-processing';
 
     /**
      * The console command description.
@@ -46,12 +46,12 @@ class FailOrReadyProcessingRequestInsurances extends Command
     protected function unstuckProcessingRequestInsurances() : void
     {
         RequestInsurance::query()->where('state', State::PROCESSING)
-            ->where("state_changed_at", "<", Carbon::now()->subMinutes(10))
+            ->where("state_changed_at", "<", Carbon::now('UTC')->subMinutes(10))
             ->get()
             ->each(function(RequestInsurance $requestInsurance) {
                 // State is updated based on retry_inconsistent
                 $stateChange = $requestInsurance->retry_inconsistent ? State::READY : State::FAILED;
-                $requestInsurance->update(["state" => $stateChange]);
+                $requestInsurance->update(["state" => $stateChange, "state_changed_at" => Carbon::now('UTC')]);
 
                 Log::info("Request insurance with id $requestInsurance->id was updated to $stateChange due to processing for too long.");
             });

--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Cego\RequestInsurance\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Cego\RequestInsurance\Enums\State;
+use Cego\RequestInsurance\Models\RequestInsurance;
+use Illuminate\Support\Facades\Log;
+
+
+class FailOrReadyProcessingRequestInsurances extends Command
+{
+    /**
+     * Name and signature of the console command
+     *
+     * @var string
+     */
+    protected $signature = 'fail-or-ready:request-insurances';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sets requests that have been processing for at least 10 minutes into either failed or ready state';
+
+    public function handle() : int
+    {
+       $this->queryDatabase(true, State::READY);
+       $this->queryDatabase(false, State::FAILED);
+
+       return 0;
+    }
+
+    protected function queryDatabase(bool $retries_inconsistent, string $stateChange) : void
+    {
+        $reqs = RequestInsurance::query()
+            ->where("state", State::PROCESSING)
+            ->where("state_changed_at", "<", Carbon::now('UTC')->subMinutes(10))
+            ->where("retry_inconsistent", '=', $retries_inconsistent);
+
+        $reqs->update(["state" => $stateChange]);
+
+        // Get ids of request insurances that have been updated.
+        $ids = $reqs->get("id");
+        Log::info(print("Request insurances with ids $ids that have been processing for 10 minutes since shutdown, with retry_inconsistent = $retries_inconsistent, were set to state $stateChange"));
+    }
+}

--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -59,6 +59,7 @@ class FailOrReadyProcessingRequestInsurances extends Command
         $stateChange = $retries_inconsistent ? State::READY : State::FAILED;
         $reqs->update(["state" => $stateChange]);
 
-        Log::info(print("Request insurances with ids $ids , with retry_inconsistent = $retries_inconsistent, were set to state $stateChange, due to processing for too long."));
+        $boolString = $retries_inconsistent ? "true" : "false";
+        Log::info(print("Request insurances with ids $ids, with retry_inconsistent = $boolString, were set to state $stateChange, due to processing for too long."));
     }
 }

--- a/src/RequestInsurance/HttpResponse.php
+++ b/src/RequestInsurance/HttpResponse.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use GuzzleHttp\Exception\ConnectException;
-use PHPUnit\Util\Annotation\DocBlock;
 
 class HttpResponse
 {
@@ -58,7 +57,6 @@ class HttpResponse
         }
 
         if ($this->isTimedOut()) {
-            $this->
             Log::error($this->connectException);
         } else {
             Log::error('No response object nor connect exception received for request');

--- a/src/RequestInsurance/HttpResponse.php
+++ b/src/RequestInsurance/HttpResponse.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use GuzzleHttp\Exception\ConnectException;
+use PHPUnit\Util\Annotation\DocBlock;
 
 class HttpResponse
 {
@@ -57,6 +58,7 @@ class HttpResponse
         }
 
         if ($this->isTimedOut()) {
+            $this->
             Log::error($this->connectException);
         } else {
             Log::error('No response object nor connect exception received for request');

--- a/src/RequestInsurance/RequestInsuranceServiceProvider.php
+++ b/src/RequestInsurance/RequestInsuranceServiceProvider.php
@@ -89,7 +89,7 @@ class RequestInsuranceServiceProvider extends ServiceProvider
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule) {
             $schedule->command('unlock:request-insurances')->everyFiveMinutes();
             $schedule->command('clean:request-insurances')->everyTenMinutes();
-            $schedule->command('fail-or-ready:request-insurances')->everyTenMinutes();
+            $schedule->command('unstuck-processing:request-insurances')->everyTenMinutes();
         });
     }
 

--- a/src/RequestInsurance/RequestInsuranceServiceProvider.php
+++ b/src/RequestInsurance/RequestInsuranceServiceProvider.php
@@ -15,7 +15,6 @@ use Cego\RequestInsurance\ViewComponents\PrettyPrint;
 use Cego\RequestInsurance\Providers\CegoIdentityProvider;
 use Cego\RequestInsurance\ViewComponents\EditApprovalsStatus;
 use Cego\RequestInsurance\ViewComponents\PrettyPrintTextArea;
-use MongoDB\Driver\Command;
 
 class RequestInsuranceServiceProvider extends ServiceProvider
 {

--- a/src/RequestInsurance/RequestInsuranceServiceProvider.php
+++ b/src/RequestInsurance/RequestInsuranceServiceProvider.php
@@ -89,7 +89,7 @@ class RequestInsuranceServiceProvider extends ServiceProvider
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule) {
             $schedule->command('unlock:request-insurances')->everyFiveMinutes();
             $schedule->command('clean:request-insurances')->everyTenMinutes();
-            $schedule->command('unstuck-processing:request-insurances')->everyTenMinutes();
+            $schedule->command('request-insurance:unstuck-processing')->everyTenMinutes();
         });
     }
 

--- a/src/RequestInsurance/RequestInsuranceServiceProvider.php
+++ b/src/RequestInsurance/RequestInsuranceServiceProvider.php
@@ -15,6 +15,7 @@ use Cego\RequestInsurance\ViewComponents\PrettyPrint;
 use Cego\RequestInsurance\Providers\CegoIdentityProvider;
 use Cego\RequestInsurance\ViewComponents\EditApprovalsStatus;
 use Cego\RequestInsurance\ViewComponents\PrettyPrintTextArea;
+use MongoDB\Driver\Command;
 
 class RequestInsuranceServiceProvider extends ServiceProvider
 {
@@ -82,12 +83,14 @@ class RequestInsuranceServiceProvider extends ServiceProvider
             Commands\RequestInsuranceService::class,
             Commands\UnlockBlockedRequestInsurances::class,
             Commands\CleanUpRequestInsurances::class,
+            Commands\FailOrReadyProcessingRequestInsurances::class
         ]);
 
         // Add specific commands to the schedule
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule) {
             $schedule->command('unlock:request-insurances')->everyFiveMinutes();
             $schedule->command('clean:request-insurances')->everyTenMinutes();
+            $schedule->command('fail-or-ready:request-insurances')->everyTenMinutes();
         });
     }
 

--- a/tests/Unit/RequestInsuranceStateTest.php
+++ b/tests/Unit/RequestInsuranceStateTest.php
@@ -239,64 +239,54 @@ class RequestInsuranceStateTest extends TestCase
     public function it_updates_requests_to_ready_if_process_for_10_minutes_and_retry_inconsistent_is_true() : void
     {
         // Arrange
-        $req1 = $this->createDummyRequestInsurance();
-        $req2 = $this->createDummyRequestInsurance();
+        $requestInsurance1 = $this->createDummyRequestInsurance();
+        $requestInsurance2 = $this->createDummyRequestInsurance();
 
-        $req1->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => true]);
-        $req2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => true]);
+        $requestInsurance1->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => true]);
+        $requestInsurance2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => true]);
 
         // Act
-        $this->artisan("fail-or-ready:request-insurances");
+        $this->artisan("unstuck-processing:request-insurances");
 
         // Assert
-        $req1->refresh();
-        $req2->refresh();
-
-        $this->assertEquals(State::READY , $req1->state);
-        $this->assertEquals(State::READY , $req2->state);
-
+        $this->assertEquals(State::READY , $requestInsurance1->refresh()->state);
+        $this->assertEquals(State::READY , $requestInsurance2->refresh()->state);
     }
 
     /** @test */
-    public function it_updates_requests_to_ready_if_process_for_10_minutes_and_retry_inconsistent_is_false()
+    public function it_updates_requests_to_false_if_process_for_10_minutes_and_retry_inconsistent_is_false()
     {
         // Arrange
-        $req1 = $this->createDummyRequestInsurance();
-        $req2 = $this->createDummyRequestInsurance();
+        $requestInsurance1 = $this->createDummyRequestInsurance();
+        $requestInsurance2 = $this->createDummyRequestInsurance();
 
-        $req1->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => false]);
-        $req2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => false]);
+        $requestInsurance1->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => false]);
+        $requestInsurance2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => false]);
 
         // Act
-        $this->artisan("fail-or-ready:request-insurances");
+        $this->artisan("unstuck-processing:request-insurances");
 
         // Assert
-        $req1->refresh();
-        $req2->refresh();
-
-        $this->assertEquals(State::FAILED , $req1->state);
-        $this->assertEquals(State::FAILED , $req2->state);
+        $this->assertEquals(State::FAILED , $requestInsurance1->refresh()->state);
+        $this->assertEquals(State::FAILED , $requestInsurance2->refresh()->state);
     }
 
     /** @test */
     public function it_does_not_update_state_if_processing_has_run_less_than_10_minutes()
     {
         // Arrange
-        $req1 = $this->createDummyRequestInsurance();
-        $req2 = $this->createDummyRequestInsurance();
+        $requestInsurance1 = $this->createDummyRequestInsurance();
+        $requestInsurance2 = $this->createDummyRequestInsurance();
 
-        $req1->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(9), "retry_inconsistent" => false]);
-        $req2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(9), "retry_inconsistent" => false]);
+        $requestInsurance1->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(9), "retry_inconsistent" => false]);
+        $requestInsurance2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(9), "retry_inconsistent" => false]);
 
         // Act
-        $this->artisan("fail-or-ready:request-insurances");
+        $this->artisan("unstuck-processing:request-insurances");
 
         // Assert
-        $req1->refresh();
-        $req2->refresh();
-
-        $this->assertEquals(State::PROCESSING , $req1->state);
-        $this->assertEquals(State::PROCESSING , $req2->state);
+        $this->assertEquals(State::PROCESSING , $requestInsurance1->state);
+        $this->assertEquals(State::PROCESSING , $requestInsurance1->state);
     }
 
     protected function createDummyRequestInsurance(): RequestInsurance

--- a/tests/Unit/RequestInsuranceStateTest.php
+++ b/tests/Unit/RequestInsuranceStateTest.php
@@ -246,7 +246,7 @@ class RequestInsuranceStateTest extends TestCase
         $requestInsurance2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => true]);
 
         // Act
-        $this->artisan("unstuck-processing:request-insurances");
+        $this->artisan(" request-insurance:unstuck-processing");
 
         // Assert
         $this->assertEquals(State::READY , $requestInsurance1->refresh()->state);
@@ -264,7 +264,7 @@ class RequestInsuranceStateTest extends TestCase
         $requestInsurance2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(11), "retry_inconsistent" => false]);
 
         // Act
-        $this->artisan("unstuck-processing:request-insurances");
+        $this->artisan("request-insurance:unstuck-processing");
 
         // Assert
         $this->assertEquals(State::FAILED , $requestInsurance1->refresh()->state);
@@ -282,7 +282,7 @@ class RequestInsuranceStateTest extends TestCase
         $requestInsurance2->update(["state" => State::PROCESSING, "state_changed_at" => Carbon::now()->subMinutes(9), "retry_inconsistent" => false]);
 
         // Act
-        $this->artisan("unstuck-processing:request-insurances");
+        $this->artisan("request-insurance:unstuck-processing");
 
         // Assert
         $this->assertEquals(State::PROCESSING , $requestInsurance1->state);

--- a/tests/Unit/ScheduleTest.php
+++ b/tests/Unit/ScheduleTest.php
@@ -15,7 +15,7 @@ class ScheduleTest extends TestCase
         // Assert
         $this->assertScheduleHasCommand('unlock:request-insurances');
         $this->assertScheduleHasCommand('clean:request-insurances');
-        $this->assertScheduleHasCommand('fail-or-ready:request-insurances');
+        $this->assertScheduleHasCommand('unstuck-processing:request-insurances');
     }
 
     /**

--- a/tests/Unit/ScheduleTest.php
+++ b/tests/Unit/ScheduleTest.php
@@ -15,6 +15,7 @@ class ScheduleTest extends TestCase
         // Assert
         $this->assertScheduleHasCommand('unlock:request-insurances');
         $this->assertScheduleHasCommand('clean:request-insurances');
+        $this->assertScheduleHasCommand('fail-or-ready:request-insurances');
     }
 
     /**

--- a/tests/Unit/ScheduleTest.php
+++ b/tests/Unit/ScheduleTest.php
@@ -15,7 +15,7 @@ class ScheduleTest extends TestCase
         // Assert
         $this->assertScheduleHasCommand('unlock:request-insurances');
         $this->assertScheduleHasCommand('clean:request-insurances');
-        $this->assertScheduleHasCommand('unstuck-processing:request-insurances');
+        $this->assertScheduleHasCommand('request-insurance:unstuck-processing');
     }
 
     /**


### PR DESCRIPTION
1. Created a new class FailOrReadyProcessingRequestInsurances that will change the state of RIs that have been processing for 10+ minutes. Whether it sets to failed or ready depends on retry_inconsistent field of RI.

Link to card:
https://trello.com/c/DRCmKyPr/385-g%C3%B8r-s%C3%A5-ri-der-sidder-stuck-i-processing-i-mere-end-10-minutter-enten-ender-i-failed-eller-tilbage-i-ready-afh%C3%A6ngig-af-retryincon 