### PR TITLE
gusb/retry-if-408-response

### DIFF
--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -3,6 +3,7 @@
 namespace Cego\RequestInsurance\Commands;
 
 use Carbon\Carbon;
+use Cego\RequestInsurance\ViewComponents\HttpCode;
 use Illuminate\Console\Command;
 use Cego\RequestInsurance\Enums\State;
 use Cego\RequestInsurance\Models\RequestInsurance;

--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -3,7 +3,6 @@
 namespace Cego\RequestInsurance\Commands;
 
 use Carbon\Carbon;
-use Cego\RequestInsurance\ViewComponents\HttpCode;
 use Illuminate\Console\Command;
 use Cego\RequestInsurance\Enums\State;
 use Cego\RequestInsurance\Models\RequestInsurance;

--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -816,7 +816,7 @@ class RequestInsurance extends SaveRetryingModel
             $this->setState(State::COMPLETED);
         // If response code is 408, we take it as a timeout and set the request to retry again later
         } elseif ($response->getCode() == 408 && $this->retry_inconsistent) {
-            $this->retryLater();
+            $this->retryLater(false);
         } elseif ($response->isRetryable()) {
             $this->retryLater(false);
         } else {

--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -815,9 +815,7 @@ class RequestInsurance extends SaveRetryingModel
         } elseif ($response->wasSuccessful()) {
             $this->setState(State::COMPLETED);
         // If response code is 408, we take it as a timeout and set the request to retry again later
-        } elseif ($response->getCode() == 408 && $this->retry_inconsistent) {
-            $this->retryLater(false);
-        } elseif ($response->isRetryable()) {
+        } elseif ($response->isRetryable() || ($response->getCode() == 408 && $this->retry_inconsistent)) {
             $this->retryLater(false);
         } else {
             $this->setState(State::FAILED);

--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -814,6 +814,9 @@ class RequestInsurance extends SaveRetryingModel
             }
         } elseif ($response->wasSuccessful()) {
             $this->setState(State::COMPLETED);
+        // If response code is 408, we take it as a timeout and set the request to retry again later
+        } elseif ($response->getCode() == 408 && $this->retry_inconsistent) {
+            $this->retryLater();
         } elseif ($response->isRetryable()) {
             $this->retryLater(false);
         } else {

--- a/tests/Unit/RequestInsuranceStateTest.php
+++ b/tests/Unit/RequestInsuranceStateTest.php
@@ -290,14 +290,15 @@ class RequestInsuranceStateTest extends TestCase
     }
 
     /** @test */
-    public function it_sets_state_to_waiting_when_response_is_408(): void
+    public function it_sets_state_to_waiting_when_response_is_408_and_retry_inconsistent_is_true(): void
     {
         // Arrange
         RequestInsuranceClient::fake(fn () => Http::response([], 408));
+        $requestInsurance = $this->createDummyRequestInsurance();
+        $requestInsurance->retry_inconsistent = true;
+        $requestInsurance->save();
 
         // Act
-        $requestInsurance = $this->createDummyRequestInsurance();
-        $requestInsurance->save();
         $this->runWorkerOnce();
 
         // Assert

--- a/tests/Unit/RequestInsuranceStateTest.php
+++ b/tests/Unit/RequestInsuranceStateTest.php
@@ -289,6 +289,22 @@ class RequestInsuranceStateTest extends TestCase
         $this->assertEquals(State::PROCESSING , $requestInsurance1->state);
     }
 
+    /** @test */
+    public function it_sets_state_to_waiting_when_response_is_408(): void
+    {
+        // Arrange
+        RequestInsuranceClient::fake(fn () => Http::response([], 408));
+
+        // Act
+        $requestInsurance = $this->createDummyRequestInsurance();
+        $requestInsurance->save();
+        $this->runWorkerOnce();
+
+        // Assert
+        $requestInsurance->refresh();
+        $this->assertEquals(State::WAITING, $requestInsurance->state);
+    }
+
     protected function createDummyRequestInsurance(): RequestInsurance
     {
         $requestInsurance = RequestInsurance::getBuilder()


### PR DESCRIPTION
Trello card: 
https://trello.com/c/vCg3blS5/597-retry-408-hvis-retryinconsistent-setting-er-sat-til-true

Description:
1. Made it so that a request insurance is retried later if the response to the request is 408 and the request has retry_inconsistent set to true.

Reason:
1. 408 in this context is more like a timeout than an actual client error.

Risks:
1. A request may be retrie even though it shouldn't but the consequences should be low. 

