### PR TITLE
gusb/handle-guzzle-exception

### DIFF
--- a/src/RequestInsurance/HttpResponse.php
+++ b/src/RequestInsurance/HttpResponse.php
@@ -152,6 +152,10 @@ class HttpResponse
             return '<REQUEST_TIMED_OUT : THIS MESSAGE WAS ADDED BY REQUEST INSURANCE>';
         }
 
+        if ($this->isRequestException()) {
+            return '<REQUEST_EXCEPTION : THIS MESSAGE WAS ADDED BY REQUEST INSURANCE>';
+        }
+
         if ($this->isInconsistent()) {
             return '<REQUEST_INCONSISTENT : THIS MESSAGE WAS ADDED BY REQUEST INSURANCE>';
         }

--- a/src/RequestInsurance/HttpResponse.php
+++ b/src/RequestInsurance/HttpResponse.php
@@ -51,7 +51,8 @@ class HttpResponse
 
     /**
      * Returns true when the request failed due to a Guzzle RequestException.
-     * The RequestException is a generalization of some other Guzzle exceptions.
+     * The RequestException is a generalization of some other Guzzle exceptions,
+     * specifically BadResponseException, TooManyRedirectsException.
      *
      * @return bool
      */

--- a/src/RequestInsurance/HttpResponse.php
+++ b/src/RequestInsurance/HttpResponse.php
@@ -74,16 +74,17 @@ class HttpResponse
 
         if ($this->isTimedOut()) {
             Log::error($this->connectException);
+
             return;
         }
 
         if ($this->isRequestException()) {
             Log::error($this->requestException);
+
             return;
         }
 
         Log::error('No response object, connect exception nor request exception was received for request');
-
     }
 
     /**

--- a/src/RequestInsurance/HttpResponse.php
+++ b/src/RequestInsurance/HttpResponse.php
@@ -12,10 +12,10 @@ class HttpResponse
 {
     protected Response $response;
     protected ConnectException $connectException;
-    protected RequestException $requestException
+    protected RequestException $requestException;
 
     /**
-     * @param Response|ConnectException $response
+     * @param Response|ConnectException|RequestException $response
      */
     public function __construct($response)
     {
@@ -49,6 +49,12 @@ class HttpResponse
         return isset($this->connectException);
     }
 
+    /**
+     * Returns true when the request failed due to a Guzzle RequestException.
+     * The RequestException is a generalization of some other Guzzle exceptions.
+     *
+     * @return bool
+     */
     public function isRequestException(): bool
     {
         return isset($this->requestException);
@@ -176,7 +182,7 @@ class HttpResponse
     }
 
     /**
-     * Gets the execution tim of the request
+     * Gets the execution time of the request
      *
      * @return float
      */

--- a/tests/Unit/HttpResponseTest.php
+++ b/tests/Unit/HttpResponseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -7,13 +8,12 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 
-
 class HttpResponseTest extends TestCase
 {
     /** @test */
     public function it_can_initialize_with_request_exception()
     {
-        $httpResponse = new HttpResponse(new RequestException("F", new Request("GET", "www.notaplaceforsho.dk")));
+        $httpResponse = new HttpResponse(new RequestException('F', new Request('GET', 'www.notaplaceforsho.dk')));
 
         $this->assertTrue($httpResponse->isRequestException());
     }
@@ -21,7 +21,7 @@ class HttpResponseTest extends TestCase
     /** @test */
     public function it_can_initialize_with_bad_response_exception()
     {
-        $httpResponse = new HttpResponse(new BadResponseException("F", new Request("GET", "www.notaplaceforsho.dk"), new Response()));
+        $httpResponse = new HttpResponse(new BadResponseException('F', new Request('GET', 'www.notaplaceforsho.dk'), new Response()));
 
         $this->assertTrue($httpResponse->isRequestException());
     }
@@ -29,7 +29,7 @@ class HttpResponseTest extends TestCase
     /** @test */
     public function it_can_initialize_with_too_many_redirects_exception()
     {
-        $httpResponse = new HttpResponse(new TooManyRedirectsException("F", new Request("GET", "www.notaplaceforsho.dk")));
+        $httpResponse = new HttpResponse(new TooManyRedirectsException('F', new Request('GET', 'www.notaplaceforsho.dk')));
 
         $this->assertTrue($httpResponse->isRequestException());
     }

--- a/tests/Unit/HttpResponseTest.php
+++ b/tests/Unit/HttpResponseTest.php
@@ -1,0 +1,36 @@
+<?php
+use Tests\TestCase;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Cego\RequestInsurance\HttpResponse;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+
+
+class HttpResponseTest extends TestCase
+{
+    /** @test */
+    public function it_can_initialize_with_request_exception()
+    {
+        $httpResponse = new HttpResponse(new RequestException("F", new Request("GET", "www.notaplaceforsho.dk")));
+
+        $this->assertTrue($httpResponse->isRequestException());
+    }
+
+    /** @test */
+    public function it_can_initialize_with_bad_response_exception()
+    {
+        $httpResponse = new HttpResponse(new BadResponseException("F", new Request("GET", "www.notaplaceforsho.dk"), new Response()));
+
+        $this->assertTrue($httpResponse->isRequestException());
+    }
+
+    /** @test */
+    public function it_can_initialize_with_too_many_redirects_exception()
+    {
+        $httpResponse = new HttpResponse(new TooManyRedirectsException("F", new Request("GET", "www.notaplaceforsho.dk")));
+
+        $this->assertTrue($httpResponse->isRequestException());
+    }
+}


### PR DESCRIPTION
Trello card: 
https://trello.com/c/wZ6NXfDR/1550-fix-at-ri-crasher-for-specifikke-guzzle-exceptions

Description: 
HttpResponse class now accepts RequestExceptions as well. It could already handle ConnectionException, but with RequestException as well, it should be able to handle any Guzzle Exception. 

Reason: 
We got many errors because RequestException does not match ConnectionException. 

