### PR TITLE
Fix trim(null) deprecation warnings spamming logs

### DIFF
--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -617,11 +617,11 @@ class RequestInsurance extends SaveRetryingModel
             $query->whereIn('state', $searchedStates);
         }
 
-        if ($request->has('url') && trim($request->get('url'))) {
+        if ($request->filled('url')) {
             $query = $query->where('url', 'like', $request->get('url'));
         }
 
-        if ($request->has('trace_id') && trim($request->get('trace_id'))) {
+        if ($request->filled('trace_id')) {
             $query = $query->where('trace_id', $request->get('trace_id'));
         }
 


### PR DESCRIPTION
Replace has() + trim() with filled() in scopeFilteredByRequest to avoid PHP 8.1+ deprecation warnings when filter params are empty.