### PR TITLE
Fix Symfony 7.4 Request::get() deprecation in scopeFilteredByRequest

### DIFF
--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -608,7 +608,7 @@ class RequestInsurance extends SaveRetryingModel
         $searchedStates = [];
 
         foreach (State::getAll() as $state) {
-            if ($request->get($state) == 'on') {
+            if ($request->query($state) == 'on') {
                 $searchedStates[] = $state;
             }
         }
@@ -618,22 +618,22 @@ class RequestInsurance extends SaveRetryingModel
         }
 
         if ($request->filled('url')) {
-            $query = $query->where('url', 'like', $request->get('url'));
+            $query = $query->where('url', 'like', $request->query('url'));
         }
 
         if ($request->filled('trace_id')) {
-            $query = $query->where('trace_id', $request->get('trace_id'));
+            $query = $query->where('trace_id', $request->query('trace_id'));
         }
 
         try {
-            if ($request->has('from') && $request->get('from') != null) {
-                $from = Carbon::parse($request->get('from'));
+            if ($request->has('from') && $request->query('from') != null) {
+                $from = Carbon::parse($request->query('from'));
                 $query = $query->whereDate('created_at', '>=', $from);
                 $query = $query->whereTime('created_at', '>=', $from);
             }
 
-            if ($request->has('to') && $request->get('to') != null) {
-                $to = Carbon::parse($request->get('to'));
+            if ($request->has('to') && $request->query('to') != null) {
+                $to = Carbon::parse($request->query('to'));
                 $query = $query->whereDate('created_at', '<=', $to);
                 $query = $query->whereTime('created_at', '<=', $to);
             }


### PR DESCRIPTION
## Summary

- Replace `$request->get(...)` with `$request->query(...)` in `RequestInsurance::scopeFilteredByRequest()` (the admin index filter scope).
- Silences the Symfony 7.4 deprecation warning that fires on every page load of the request-insurances admin UI:
  > `Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead.`
- The admin filter form submits via GET, so `query()` is the precise, behavior-preserving replacement (previously `get()` would also fall back to `attributes` and `request` body, neither of which carry these inputs).

## Why

Symfony deprecated `Request::get()` because of its ambiguous lookup order across `attributes`, `query`, then `request` bags — a long-standing source of subtle bugs. Picking `query()` here narrows the lookup to query-string params, which is what the form actually sends.

## Test plan

- [ ] CI: existing PHPUnit suite passes.
- [ ] Manual: load the request-insurances admin index in any consuming service (e.g. money-limits) and confirm the deprecation no longer appears in logs.
- [ ] Manual: exercise each filter input — state checkboxes, url, trace_id, from, to — and confirm filtering still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)