### PR TITLE
Normalize insured-request HTTP method to uppercase

### DIFF
--- a/src/RequestInsurance/AsyncRequests/RequestPool.php
+++ b/src/RequestInsurance/AsyncRequests/RequestPool.php
@@ -76,7 +76,7 @@ class RequestPool
      */
     private function convertRequestToPromise(Client $client, RequestInsurance $requestInsurance): PromiseInterface
     {
-        return $client->requestAsync($requestInsurance->method, $requestInsurance->url, [
+        return $client->requestAsync(mb_strtoupper($requestInsurance->method), $requestInsurance->url, [
             'headers'     => array_merge($requestInsurance->getHeadersCastToArray(), ['User-Agent' => sprintf('RequestInsurance %s', Config::get('app.name', 'unknown'))]),
             'body'        => $requestInsurance->payload,
             'timeout'     => $requestInsurance->getEffectiveTimeout(),

--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -150,6 +150,8 @@ class RequestInsurance extends SaveRetryingModel
                 throw new EmptyPropertyException('method', $request);
             }
 
+            $request->method = mb_strtoupper($request->method);
+
             // Throw exception if url is not set
             if ( ! $request->url) {
                 throw new EmptyPropertyException('url', $request);


### PR DESCRIPTION
## Problem
Replaying an insured request logs a Guzzle deprecation:

> Since guzzlehttp/guzzle 7.11: Passing a non-uppercase HTTP method to `Client::requestAsync()` is deprecated; guzzlehttp/guzzle 8.0 will preserve HTTP method casing.

**Root cause — inconsistent storage.** `Contracts/HttpRequest::setMethod()` already `mb_strtoupper`s the method, but `RequestInsuranceBuilder::method()` (and direct `RequestInsurance::create(['method' => ...])`) store the verb verbatim. Producers passing a lowercase verb — e.g. `GamesGlobalClient`, `PragmaticPlayClient`, `PariplayClient` in the monolith all do `->method('post')` — persist a lowercase method, which is then replayed lowercase. This is noisy today and a latent break (guzzle 8.0 will send the literal lowercase verb).

## Fix — two layers, each for a distinct reason
1. **Storage (root cause)** — normalize the method in the model `saving` hook, so every Eloquent write path (`builder->create()`, `RequestInsurance::create([...])`, `save()`) stores the canonical uppercase form. This fixes the data for **all** readers, not just the Guzzle send path.
2. **Send-time guard (legacy/in-flight rows)** — keep `mb_strtoupper()` at `RequestPool::convertRequestToPromise()`. The worker flips rows to `PROCESSING` via a **bulk `query()->update()` + `forceFill`** that bypasses model events/mutators, so rows already stored lowercase are **not** normalized before their first send. The guard guarantees no lowercase verb ever reaches Guzzle, regardless of how/when the row was written.

New rows become canonical (layer 1); existing lowercase rows still send correctly and age out (layer 2).

No behaviour change for already-uppercase methods (existing tests use `POST`). A regression test would need the test fake (`AsyncRequests/Fake/MockHandler`) to expose the captured request — happy to add that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)