### PR TITLE
Add config option to retry inconsistent responses by default

### DIFF
--- a/publishable/config/request-insurance.php
+++ b/publishable/config/request-insurance.php
@@ -15,6 +15,14 @@ return [
     'enabled' => env('REQUEST_INSURANCE_ENABLED', true),
 
     /*
+    | Sets the default value for the retry_inconsistent option on new request insurances.
+    | When enabled, request insurances that end up in an inconsistent state are retried by
+    | default instead of failed. This can still be overridden per request via the builder.
+    */
+
+    'retryInconsistentDefault' => env('REQUEST_INSURANCE_RETRY_INCONSISTENT_DEFAULT', false),
+
+    /*
     | Sets if keep alive should be sent with curl requests
     */
 

--- a/src/RequestInsurance/RequestInsuranceBuilder.php
+++ b/src/RequestInsurance/RequestInsuranceBuilder.php
@@ -103,13 +103,17 @@ class RequestInsuranceBuilder
     }
 
     /**
-     * Makes RI automatically retry inconsistent request insurances, instead of failing them.
+     * Controls whether RI automatically retries inconsistent request insurances, instead of failing them.
+     *
+     * Explicitly setting this overrides the 'retryInconsistentDefault' config option for this request.
+     *
+     * @param bool $retry
      *
      * @return $this
      */
-    public function retryInconsistentState(): RequestInsuranceBuilder
+    public function retryInconsistentState(bool $retry = true): RequestInsuranceBuilder
     {
-        return $this->set('retry_inconsistent', true);
+        return $this->set('retry_inconsistent', $retry);
     }
 
     /**

--- a/src/RequestInsurance/RequestInsuranceBuilder.php
+++ b/src/RequestInsurance/RequestInsuranceBuilder.php
@@ -5,6 +5,7 @@ namespace Cego\RequestInsurance;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\Support\Facades\Config;
 use Cego\RequestInsurance\Models\RequestInsurance;
 
 class RequestInsuranceBuilder
@@ -206,6 +207,12 @@ class RequestInsuranceBuilder
     public function create(): RequestInsurance
     {
         $this->headers(self::injectTraceHeaders($this->data['headers'] ?? []));
+
+        // Apply the configured default for retry_inconsistent, unless it was
+        // explicitly set on this builder (e.g. via retryInconsistentState()).
+        if ( ! Arr::has($this->data, 'retry_inconsistent')) {
+            $this->set('retry_inconsistent', (bool) Config::get('request-insurance.retryInconsistentDefault', false));
+        }
 
         return RequestInsurance::create($this->data);
     }

--- a/tests/Unit/RequestInsuranceBuilderTest.php
+++ b/tests/Unit/RequestInsuranceBuilderTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use InvalidArgumentException;
+use Illuminate\Support\Facades\Config;
 use Cego\RequestInsurance\Models\RequestInsurance;
 
 class RequestInsuranceBuilderTest extends TestCase
@@ -48,6 +49,58 @@ class RequestInsuranceBuilderTest extends TestCase
         $this->assertCount(1, RequestInsurance::all());
         $requestInsurance = RequestInsurance::first();
 
+        $this->assertEquals(true, $requestInsurance->retry_inconsistent);
+    }
+
+    public function test_it_defaults_retry_inconsistent_to_false(): void
+    {
+        // Act
+        RequestInsurance::getBuilder()
+            ->method('POST')
+            ->url('https://MyDev.lupinsdev.dk')
+            ->headers(['Content-Type' => 'application/json'])
+            ->payload(['data' => [1, 2, 3]])
+            ->create();
+
+        // Assert
+        $requestInsurance = RequestInsurance::first();
+        $this->assertEquals(false, $requestInsurance->retry_inconsistent);
+    }
+
+    public function test_it_defaults_retry_inconsistent_from_config(): void
+    {
+        // Arrange
+        Config::set('request-insurance.retryInconsistentDefault', true);
+
+        // Act
+        RequestInsurance::getBuilder()
+            ->method('POST')
+            ->url('https://MyDev.lupinsdev.dk')
+            ->headers(['Content-Type' => 'application/json'])
+            ->payload(['data' => [1, 2, 3]])
+            ->create();
+
+        // Assert
+        $requestInsurance = RequestInsurance::first();
+        $this->assertEquals(true, $requestInsurance->retry_inconsistent);
+    }
+
+    public function test_explicit_retry_inconsistent_state_overrides_config_default(): void
+    {
+        // Arrange
+        Config::set('request-insurance.retryInconsistentDefault', false);
+
+        // Act
+        RequestInsurance::getBuilder()
+            ->method('POST')
+            ->url('https://MyDev.lupinsdev.dk')
+            ->headers(['Content-Type' => 'application/json'])
+            ->payload(['data' => [1, 2, 3]])
+            ->retryInconsistentState()
+            ->create();
+
+        // Assert
+        $requestInsurance = RequestInsurance::first();
         $this->assertEquals(true, $requestInsurance->retry_inconsistent);
     }
 

--- a/tests/Unit/RequestInsuranceBuilderTest.php
+++ b/tests/Unit/RequestInsuranceBuilderTest.php
@@ -104,6 +104,25 @@ class RequestInsuranceBuilderTest extends TestCase
         $this->assertEquals(true, $requestInsurance->retry_inconsistent);
     }
 
+    public function test_explicit_retry_inconsistent_state_false_overrides_config_default(): void
+    {
+        // Arrange
+        Config::set('request-insurance.retryInconsistentDefault', true);
+
+        // Act
+        RequestInsurance::getBuilder()
+            ->method('POST')
+            ->url('https://MyDev.lupinsdev.dk')
+            ->headers(['Content-Type' => 'application/json'])
+            ->payload(['data' => [1, 2, 3]])
+            ->retryInconsistentState(false)
+            ->create();
+
+        // Assert
+        $requestInsurance = RequestInsurance::first();
+        $this->assertEquals(false, $requestInsurance->retry_inconsistent);
+    }
+
     public function test_it_does_not_allow_empty_method(): void
     {
         // Assert


### PR DESCRIPTION
## Summary

Adds a `retryInconsistentDefault` config option (settable via the `REQUEST_INSURANCE_RETRY_INCONSISTENT_DEFAULT` env variable) that controls the default value of `retry_inconsistent` for newly created request insurances.

When enabled, request insurances that end up in an inconsistent state are retried by default instead of being failed, without having to call `->retryInconsistentState()` on each builder.

## Behaviour

- Defaults to `false`, preserving the existing behaviour.
- The default is applied in `RequestInsuranceBuilder::create()` only when `retry_inconsistent` has not been explicitly set, so per-request `->retryInconsistentState()` calls still take precedence.

## Tests

Added builder tests covering:
- Default of `false` when the config is untouched.
- Picking up `true` from the config option.
- Explicit `->retryInconsistentState()` overriding the config default.