### PR TITLE
Modernize the web UI with a Tailwind 4 light/dark interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,163 @@
 
 [![QA](https://github.com/cego/request-insurance/actions/workflows/quality-assurance.yml/badge.svg)](https://github.com/cego/request-insurance/actions/workflows/quality-assurance.yml)
 
-# Supported versions
+Guaranteed delivery of outbound HTTP requests for Laravel.
 
-| Package version | PHP versions supported | Status
-|----------|------------------------|---|
-| ^1       | ^7.4,^8.0              | Security and bug fixes only
-| ^2       | ^8.3                   | Security and bug fixes only
-| ^3       | ^8.3                   | Active development
+Instead of firing an HTTP request and hoping it arrives, you *insure* it: the request is persisted
+to the database first, then delivered asynchronously by a worker that retries with exponential
+backoff, keeps a log of every attempt, and hands permanently failing requests to a human through a
+built-in management UI where they can be inspected, edited (with peer approval), retried, or
+abandoned.
+
+Use it for requests that must not be lost when the receiving service is down, times out, or your
+own process dies mid-request — webhooks, downstream service calls, third-party API writes.
+
+## Supported versions
+
+| Package version | PHP versions supported | Status |
+|-----------------|------------------------|--------|
+| ^1              | ^7.4, ^8.0             | Security and bug fixes only |
+| ^2              | ^8.3                   | Security and bug fixes only |
+| ^3              | ^8.3                   | Active development |
+
+## Installation
+
+```bash
+composer require cego/request-insurance
+```
+
+The service provider is auto-discovered and the migrations load automatically — run them with
+`php artisan migrate`. To tweak configuration, publish the config file:
+
+```bash
+php artisan vendor:publish --provider="Cego\RequestInsurance\RequestInsuranceServiceProvider"
+```
+
+## Creating requests
+
+Build and persist a request with the fluent builder — this only writes a database row, delivery
+happens asynchronously:
+
+```php
+use Cego\RequestInsurance\Models\RequestInsurance;
+
+RequestInsurance::getBuilder()
+    ->url('https://api.example.com/webhooks')
+    ->method('post')
+    ->payload(['event' => 'order.shipped', 'order_id' => 123])
+    ->headers(['Authorization' => 'Bearer ' . $token])
+    ->traceId($traceId)      // optional: correlation id, searchable in the UI
+    ->priority(5)            // optional: zero-based, 0 is processed first
+    ->timeoutMs(5000)        // optional: per-request timeout
+    ->create();
+```
+
+## Processing
+
+A long-lived worker polls for requests that are due and delivers them:
+
+```bash
+php artisan process:request-insurances
+```
+
+Run one or many — workers coordinate through row locking (`SELECT … FOR UPDATE SKIP LOCKED` on
+MySQL 8+), pick requests in priority order, and process them in batches (`batchSize`, optionally
+with concurrent HTTP via `concurrentHttpEnabled`).
+
+### Lifecycle
+
+```mermaid
+flowchart LR
+    WAITING --> READY --> PENDING --> PROCESSING
+    PROCESSING -->|2xx| COMPLETED
+    PROCESSING -->|4xx| FAILED
+    PROCESSING -->|5xx / timeout| WAITING
+    FAILED -->|retry / edit| READY
+    FAILED -->|abandon| ABANDONED
+```
+
+| State | Meaning |
+|-------|---------|
+| `WAITING` | Waiting for its `retry_at` timestamp before becoming ready |
+| `READY` | Ready for a worker to pick up (default state) |
+| `PENDING` | Reserved by a worker, about to be processed |
+| `PROCESSING` | Actively being sent |
+| `COMPLETED` | Delivered with a successful response |
+| `FAILED` | Received a response or timeout that requires human intervention |
+| `ABANDONED` | Given up on — will never be processed again |
+
+Server errors and timeouts are retried with exponential backoff (`retry_factor ^ attempts`
+seconds, factor 2 by default, capped at `retry_cap`, 1 hour by default) up to
+`maximumNumberOfRetries`. Client errors (4xx) fail immediately — resending the same request would
+just fail again, so a human decides: edit it, retry it, or abandon it. Inconsistent outcomes
+(e.g. the process died mid-request) fail by default but can be retried automatically via
+`retryInconsistentDefault` or per request with `->retryInconsistentState()`.
+
+### Maintenance
+
+The package schedules its own housekeeping (offset per application so fleets do not thunder):
+
+| Command | Cadence | Purpose |
+|---------|---------|---------|
+| `unlock:request-insurances` | every 5 min | Releases requests stuck in `PENDING` |
+| `request-insurance:unstuck-processing` | every 10 min | Fails or readies requests stuck in `PROCESSING` |
+| `clean:request-insurances` | every 10 min | Deletes `COMPLETED` rows older than `cleanUpKeepDays` |
+
+## Encryption and masking
+
+Sensitive parts of a request can be encrypted at rest and are shown masked in the UI:
+
+```php
+RequestInsurance::getBuilder()
+    ->headers(['X-Api-Key' => $secret])
+    ->encryptHeader('X-Api-Key')
+    ->payload(['card' => $number])
+    ->encryptPayloadField('card')
+    ->create();
+```
+
+`Authorization` headers are always encrypted by default — see `fieldsToAutoEncrypt` in the config.
+
+## Events
+
+Hook into processing with standard Laravel event listeners:
+
+| Event | Fired |
+|-------|-------|
+| `RequestBeforeProcess` | Before a request is sent |
+| `RequestSuccessful` | On a 2xx response |
+| `RequestClientError` | On a 4xx response |
+| `RequestServerError` | On a 5xx response |
+| `RequestFailed` | When a request transitions to `FAILED` |
+| `RequestInconsistent` | When a request ends in an inconsistent state |
+
+All live under `Cego\RequestInsurance\Events`.
+
+## Management UI
+
+The package ships a web UI at `/vendor/request-insurances` (route name
+`request-insurances.index`) with automatic light/dark mode:
+
+- Pipeline overview with live per-state counts and cursor pagination
+- Filtering by trace id, url, date range, and state
+- Bulk retry / abandon of selected requests
+- Per-request inspection: payload, headers, timings, response, and the full attempt log
+- Editing of failed requests (method, url, payload, headers, priority) gated behind
+  four-eyes approval, with a diff view and an audit trail of applied edits
+
+Protect the `/vendor` path with your application's own auth middleware — the package does not
+impose any.
+
+## Monitoring
+
+JSON endpoints suitable for dashboards and alerting: `/vendor/request-insurances/load` (worker
+load), `/monitor` (active/failed totals), and `/monitor_segmented` (per-state counts). If
+[spatie/laravel-prometheus](https://github.com/spatie/laravel-prometheus) is installed, matching
+Prometheus gauges are registered automatically.
+
+## Development
+
+```bash
+vendor/bin/phpunit
+vendor/bin/php-cs-fixer fix
+```

--- a/publishable/routes/web.php
+++ b/publishable/routes/web.php
@@ -3,9 +3,13 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Middleware\VerifyCsrfToken;
 
+// The monitoring endpoints are fetched by the dashboard (asynchronously, so a slow
+// count never blocks page load), so they run under the same `web` session as the
+// dashboard rather than `api` — otherwise SSO/forward-auth redirects the XHR to the
+// login provider and the cross-origin redirect is blocked by CORS.
 Route::namespace('Cego\RequestInsurance\Controllers')
     ->prefix('vendor')
-    ->middleware('api')
+    ->middleware('web')
     ->group(function () {
         Route::get('request-insurances/load', [
             'uses' => 'RequestInsuranceController@load',
@@ -30,6 +34,16 @@ Route::namespace('Cego\RequestInsurance\Controllers')
         Route::resource('request-insurances', 'RequestInsuranceController')
             ->only(['index', 'show', 'destroy'])
             ->withoutMiddleware(VerifyCsrfToken::class);
+
+        Route::post('request-insurances/retry-selected', [
+            'uses' => 'RequestInsuranceController@retrySelected',
+            'as'   => 'request-insurances.retry-selected',
+        ])->withoutMiddleware(VerifyCsrfToken::class);
+
+        Route::post('request-insurances/abandon-selected', [
+            'uses' => 'RequestInsuranceController@abandonSelected',
+            'as'   => 'request-insurances.abandon-selected',
+        ])->withoutMiddleware(VerifyCsrfToken::class);
 
         Route::post('request-insurances/{request_insurance}/retry', [
             'uses' => 'RequestInsuranceController@retry',

--- a/publishable/views/components/http-code.blade.php
+++ b/publishable/views/components/http-code.blade.php
@@ -1,1 +1,5 @@
-<span class="chip chip-{{ $badgeColor ?: 'secondary' }} font-mono tabular-nums">{{ $httpCode ?: '·' }}</span>
+@if($httpCode)
+    <span class="chip chip-{{ $badgeColor ?: 'secondary' }} font-mono tabular-nums">{{ $httpCode }}</span>
+@else
+    <span class="font-mono text-slate-400 dark:text-slate-500" title="No response yet">—</span>
+@endif

--- a/publishable/views/components/http-code.blade.php
+++ b/publishable/views/components/http-code.blade.php
@@ -1,3 +1,1 @@
-<div class="badge badge-{{ $badgeColor }}">
-    {{ $httpCode }}
-</div>
+<span class="chip chip-{{ $badgeColor ?: 'secondary' }} font-mono tabular-nums">{{ $httpCode ?: '·' }}</span>

--- a/publishable/views/components/pretty-print-text-area.blade.php
+++ b/publishable/views/components/pretty-print-text-area.blade.php
@@ -1,13 +1,4 @@
-<textarea name="{{$name}}" class="w-100 form-control" @disabled($disabled)
-onfocus="(() => {
-        this.style.overflow = 'hidden';
-        this.style.height = 0;
-        this.style.height = this.scrollHeight + 'px';
-    })()"
-          onkeyup="(() => {
-        this.style.overflow = 'hidden';
-        this.style.height = 0;
-        this.style.height = this.scrollHeight + 'px';
-    })()">
-{{$content}}
-</textarea>
+<textarea name="{{ $name }}" @disabled($disabled)
+    class="w-full rounded-xl border bg-white p-3 font-mono text-xs text-slate-950 shadow-xs disabled:opacity-60 dark:bg-slate-950 dark:text-white"
+    oninput="this.style.overflow='hidden';this.style.height=0;this.style.height=this.scrollHeight+'px'"
+    onfocus="this.style.overflow='hidden';this.style.height=0;this.style.height=this.scrollHeight+'px'">{{ $content }}</textarea>

--- a/publishable/views/components/pretty-print.blade.php
+++ b/publishable/views/components/pretty-print.blade.php
@@ -1,1 +1,1 @@
-<pre><code class="json">{{ $content }}</code></pre>
+<pre class="overflow-x-auto whitespace-pre-wrap break-words rounded-xl bg-terminal text-xs leading-5 [&>code]:!bg-transparent [&>code]:!p-3 [&>code]:text-slate-200"><code class="json">{{ $content }}</code></pre>

--- a/publishable/views/components/pretty-print.blade.php
+++ b/publishable/views/components/pretty-print.blade.php
@@ -1,1 +1,5 @@
-<pre class="overflow-x-auto whitespace-pre-wrap break-words rounded-xl bg-terminal text-xs leading-5 [&>code]:!bg-transparent [&>code]:!p-3 [&>code]:text-slate-200"><code class="json">{{ $content }}</code></pre>
+@if(filled($content))
+    <pre class="overflow-x-auto whitespace-pre-wrap break-words rounded-xl bg-terminal text-xs leading-5 [&>code]:!bg-transparent [&>code]:!p-3 [&>code]:text-slate-200"><code class="json">{{ $content }}</code></pre>
+@else
+    <span class="text-slate-400 dark:text-slate-500">—</span>
+@endif

--- a/publishable/views/components/status.blade.php
+++ b/publishable/views/components/status.blade.php
@@ -1,3 +1,7 @@
-<div class="badge badge-{{ $statusColor }}">
+<?php use Cego\RequestInsurance\Enums\State; ?>
+<span class="chip chip-{{ $statusColor }}">
+    @if($requestInsurance->inOneOfStates(State::PENDING, State::PROCESSING))
+        <span class="size-1.5 animate-pulse rounded-full bg-current motion-reduce:animate-none"></span>
+    @endif
     {{ $statusText }}
-</div>
+</span>

--- a/publishable/views/components/status.blade.php
+++ b/publishable/views/components/status.blade.php
@@ -1,6 +1,7 @@
 <?php use Cego\RequestInsurance\Enums\State; ?>
+{{-- Also rendered by EditApprovalsStatus, which provides no $requestInsurance. --}}
 <span class="chip chip-{{ $statusColor }}">
-    @if($requestInsurance->inOneOfStates(State::PENDING, State::PROCESSING))
+    @if(isset($requestInsurance) && $requestInsurance->inOneOfStates(State::PENDING, State::PROCESSING))
         <span class="size-1.5 animate-pulse rounded-full bg-current motion-reduce:animate-none"></span>
     @endif
     {{ $statusText }}

--- a/publishable/views/components/timestamp.blade.php
+++ b/publishable/views/components/timestamp.blade.php
@@ -1,0 +1,5 @@
+@if($value)
+    <time datetime="{{ $value->toIso8601String() }}" data-ts="{{ $value->toIso8601String() }}" title="{{ $value->format('Y-m-d H:i:s') }}">{{ $value->format('Y-m-d H:i:s') }}</time>
+@else
+    <span class="text-slate-400 dark:text-slate-500">·</span>
+@endif

--- a/publishable/views/edit-history.blade.php
+++ b/publishable/views/edit-history.blade.php
@@ -1,102 +1,64 @@
-<?php use Cego\RequestInsurance\Enums\State;
+@extends('request-insurance::layouts.master')
 
-?>
-@extends("request-insurance::layouts.master")
+@section('title', 'Edit history #' . $requestInsurance->id . ' · Request Insurance')
 
-@section("content")
-    <div class="container-flex mt-5 col-12">
-        <div class="row">
-            <div class="col-12">
-                <h1 class="">Inspecting request insurance edit history <strong>#{{ $requestInsurance->id }}</strong> <x-request-insurance-status :requestInsurance="$requestInsurance" /></h1>
+@section('content')
+    <div class="space-y-6">
+        <nav aria-label="Breadcrumb" class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+            <a href="{{ route('request-insurances.index') }}" class="rounded hover:text-insurance">Pipeline</a>
+            <span aria-hidden="true">/</span>
+            <a href="{{ route('request-insurances.show', $requestInsurance) }}" class="rounded hover:text-insurance">Request #{{ $requestInsurance->id }}</a>
+            <span aria-hidden="true">/</span>
+            <span class="font-medium text-slate-900 dark:text-white">Edit history</span>
+        </nav>
+
+        <header class="border-b pb-6">
+            <p class="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-insurance">Audit trail</p>
+            <div class="mt-2 flex flex-wrap items-center gap-3">
+                <h1 class="text-3xl font-black tracking-[-0.04em] text-slate-950 sm:text-4xl dark:text-white">Edit history</h1>
+                <x-request-insurance-status :requestInsurance="$requestInsurance" />
             </div>
-            <!-- Request -->
-            <div class="col-12">
-                <div class="card">
-                    <div class="card-body">
-                        <div class="card-title text-center">
-                            <h3>Current Request</h3>
-                            <hr>
-                        </div>
-                        <div class="card-text">
-                            <table class="table-hover w-100 table-vertical table-striped">
-                                <tbody>
-                                <tr>
-                                    <td>RequestInsurance Id:</td>
-                                    <td>{{ $requestInsurance->id }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Priority:</td>
-                                    <td>{{ $requestInsurance->priority }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Method:</td>
-                                    <td>{{ mb_strtoupper($requestInsurance->method) }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Url:</td>
-                                    <td>{{ urldecode($requestInsurance->url) }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Payload:</td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->getOriginal('payload')"/></td>
-                                </tr>
-                                <tr>
-                                    <td>Headers:</td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->getOriginal('headers')"/></td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
+        </header>
+
+        <section aria-labelledby="current-heading" class="overflow-hidden rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+            <div class="border-b px-5 py-4 sm:px-6">
+                <p class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.16em] text-slate-400">As it is now</p>
+                <h2 id="current-heading" class="mt-1 text-lg font-extrabold text-slate-950 dark:text-white">Current request</h2>
             </div>
-            @php
-                // Get edits from most recent to oldest
-                $appliedEdits = $requestInsurance->edits()->where('applied_at', '<>', null)->orderBy('applied_at', 'DESC');
-            @endphp
-            @foreach($appliedEdits->get() as $edit)
-                <!-- Earlier Request States -->
-                <div class="col-12 mt-3">
-                    <div class="card">
-                        <div class="card-body">
-                            <div class="card-title text-center">
-                                <h3>{{$edit->applied_at}}</h3>
-                                <hr>
-                            </div>
-                            <div class="card-text">
-                                <table class="table-hover w-100 table-vertical table-striped">
-                                    <tbody>
-                                    <tr>
-                                        <td>RequestInsurance Id:</td>
-                                        <td>{{ $requestInsurance->id }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Priority:</td>
-                                        <td>{{ $edit->old_priority }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Method:</td>
-                                        <td>{{ mb_strtoupper($edit->old_method) }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Url:</td>
-                                        <td>{{ urldecode($edit->old_url) }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Payload:</td>
-                                        <td style="max-width:1px"><x-request-insurance-pretty-print :content="$edit->old_payload"/></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Headers:</td>
-                                        <td style="max-width:1px"><x-request-insurance-pretty-print :content="$edit->old_headers"/></td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
+            <div class="p-5 sm:p-6">
+                <table class="kv w-full font-mono text-[13px]">
+                    <tbody>
+                        <tr><td>Id</td><td>{{ $requestInsurance->id }}</td></tr>
+                        <tr><td>Priority</td><td>{{ $requestInsurance->priority }}</td></tr>
+                        <tr><td>Method</td><td class="font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td></tr>
+                        <tr><td>Url</td><td class="break-all">{{ urldecode($requestInsurance->url) }}</td></tr>
+                        <tr><td>Payload</td><td><x-request-insurance-pretty-print :content="$requestInsurance->getOriginal('payload')"/></td></tr>
+                        <tr><td>Headers</td><td><x-request-insurance-pretty-print :content="$requestInsurance->getOriginal('headers')"/></td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        @php $appliedEdits = $requestInsurance->edits()->where('applied_at', '<>', null)->orderBy('applied_at', 'DESC'); @endphp
+        @foreach($appliedEdits->get() as $edit)
+            <section class="overflow-hidden rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+                <div class="flex flex-wrap items-center gap-3 border-b px-5 py-4 sm:px-6">
+                    <h2 class="text-lg font-extrabold text-slate-950 dark:text-white">Before edit applied</h2>
+                    <span class="font-mono text-sm text-slate-500 dark:text-slate-400"><x-request-insurance-timestamp :value="$edit->applied_at" /></span>
                 </div>
-            @endforeach
-        </div>
+                <div class="p-5 sm:p-6">
+                    <table class="kv w-full font-mono text-[13px]">
+                        <tbody>
+                            <tr><td>Id</td><td>{{ $requestInsurance->id }}</td></tr>
+                            <tr><td>Priority</td><td>{{ $edit->old_priority }}</td></tr>
+                            <tr><td>Method</td><td class="font-bold">{{ mb_strtoupper($edit->old_method) }}</td></tr>
+                            <tr><td>Url</td><td class="break-all">{{ urldecode($edit->old_url) }}</td></tr>
+                            <tr><td>Payload</td><td><x-request-insurance-pretty-print :content="$edit->old_payload"/></td></tr>
+                            <tr><td>Headers</td><td><x-request-insurance-pretty-print :content="$edit->old_headers"/></td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endforeach
     </div>
 @endsection

--- a/publishable/views/index.blade.php
+++ b/publishable/views/index.blade.php
@@ -1,153 +1,233 @@
-<?php use Cego\RequestInsurance\Enums\State;
-
-?>
+<?php use Cego\RequestInsurance\Enums\State; ?>
 @extends('request-insurance::layouts.master')
 
+@section('title', 'Pipeline · Request Insurance')
+
 @section('content')
-    <div class="container-flex">
-        <div class="row">
-            <div class="col-12">
+    @php
+        // Lifecycle stages shown in the header strip: the success path, then the
+        // divergent exceptions branch. Counts are filled by monitor_segmented.
+        $stages = [
+            ['state' => State::WAITING,    'branch' => false],
+            ['state' => State::READY,      'branch' => false],
+            ['state' => State::PENDING,    'branch' => false],
+            ['state' => State::PROCESSING, 'branch' => false],
+            ['state' => State::COMPLETED,  'branch' => false],
+            ['state' => State::FAILED,     'branch' => true],
+            ['state' => State::ABANDONED,  'branch' => true],
+        ];
+    @endphp
 
-                <div class="pt-5">
-                    <div class="form-group form-inline">
-                        <h1 class="">Request Insurance: </h1>
-                    </div>
-                    <div class="pb-5">
-                        <div class="mr-5">
-                            <div class="badge mr-2">{{ $requestInsurances->total() }}</div><span class="mr-5"><strong>Requests in total</strong></span>
-                            <span id="ajax-managed-request-count">
-                                @foreach(State::getAll() as $state)
-                                    <div id="{{$state}}-request-count" class="badge badge-{{State::getBootstrapColor($state)}} mr-2">
-                                        <div class="spinner-grow spinner-grow-sm" role="status">
-                                            <span class="sr-only">Loading...</span>
-                                        </div>
-                                    </div>
-                                    <span class="mr-5"><strong>{{ ucfirst(strtolower($state)) }}</strong></span>
-                                @endforeach
+    <div class="space-y-8">
+        <section class="max-w-3xl">
+            <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-insurance">Request pipeline</p>
+            <h1 class="text-4xl font-black tracking-[-0.04em] text-slate-950 sm:text-5xl dark:text-white">Every request lands.<br><span class="text-slate-400 dark:text-slate-500">Or you learn why.</span></h1>
+            <p class="mt-5 max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300">Guaranteed asynchronous HTTP delivery — with retries, edits, approvals, and a full audit trail for every request.</p>
+        </section>
 
-                                <script type="text/javascript">
-                                    $(document).ready(function () {
-                                        let states = ['{!! implode("', '", State::getAll()) !!}'];
-
-                                        fetch('{{ route('request-insurances.monitor_segmented') }}')
-                                            .then(response => response.json())
-                                            .then(function (response) {
-                                                states.forEach(state => $('#' + state + '-request-count').text(response[state]))
-                                            })
-                                            .catch(function (error) {
-                                                // set #ajax-managed-request-count children to alert box
-                                                $('#ajax-managed-request-count').html(`<span class="alert alert-danger" role="alert">Could not fetch segmented request statistics: ${error}</span>`);
-                                                console.log(error);
-                                            });
-                                    });
-                                </script>
-                            </span>
+        {{-- Lifecycle flow strip: success path, then a divergent exceptions branch. --}}
+        <section aria-label="Requests per state" class="overflow-hidden rounded-2xl border bg-white p-1 shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+            <div class="flex items-stretch overflow-x-auto">
+                <div class="flex flex-1 items-stretch">
+                    @foreach($stages as $i => $stage)
+                        @if($stage['branch'] && ($stages[$i - 1]['branch'] ?? false) === false)
+                            </div><div class="ml-2 flex items-stretch border-l border-dashed pl-2">
+                        @endif
+                        @php $tone = 'tone-' . State::getBootstrapColor($stage['state']); @endphp
+                        <div class="min-w-[7.5rem] flex-1 px-5 py-4">
+                            <div class="flex items-center gap-1.5 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
+                                <span class="size-1.5 rounded-full bg-current {{ $tone }}"></span>{{ ucfirst(strtolower($stage['state'])) }}
+                            </div>
+                            <div id="count-{{ $stage['state'] }}" class="mt-1 font-mono text-[28px] leading-none tabular-nums {{ $tone }}">·</div>
                         </div>
-                    </div>
-
-                    <div>
-                        <div class="clearfix mb-3">
-                            <form method="get" class="float-right form-inline">
-                                <div class="form-group mr-5">
-                                    <label class="form-check-label mr-3">
-                                        Trace ID: <input class="form-control ml-2" type="text" name="trace_id" style="width: 250px" placeholder="trace_id" value="{{ old("trace_id") }}">
-                                    </label>
-                                    <label class="form-check-label mr-3">
-                                        Url: <input class="form-control ml-2" type="text" name="url" style="width: 250px" placeholder="% (SQL LIKE)" value="{{ old("url") }}">
-                                    </label>
-                                    <label class="form-check-label mr-3">
-                                        From: <input class="form-control ml-2" type="datetime-local" name="from" style="width: 200px" placeholder="dd-mm-yyyy-T" value="{{ old("from") }}">
-                                    </label>
-                                    <label class="form-check-label">
-                                        To: <input class="form-control ml-2" type="datetime-local" name="to" style="width: 200px" placeholder="dd-mm-yyyy-T" value="{{ old("to") }}">
-                                    </label>
-                                </div>
-
-                                <span class="mr-3">State:</span>
-                                @foreach(State::getAll() as $state)
-                                    <div class="form-check form-check-inline">
-                                        <label class="form-check-label">
-                                            <input class="form-check-input check-lg" type="checkbox" name="{{ $state }}" {{ old($state) == "on" ? "checked" : "" }}> {{ ucfirst(strtolower($state)) }}
-                                        </label>
-                                    </div>
-                                @endforeach
-                                <button class="btn btn-primary" type="submit">Filter</button>
-                                <a href="{{ url()->current() }}" class="btn btn-secondary ml-2">Clear Filters</a>
-                            </form>
-                        </div>
-
-                        <table class="table table-hover border bg-white">
-                            <thead>
-                            <tr>
-                                <th>id</th>
-                                <th>Priority</th>
-                                <th>Method</th>
-                                <th>Status</th>
-                                <th>Url</th>
-                                <th>Payload</th>
-                                <th>State</th>
-                                <th style="width: 185px">State changed at</th>
-                                <th>Attempts</th>
-                                <th style="width: 185px">Next attempt at</th>
-                                <th style="width: 185px">Created at</th>
-                                <th style="width: 200px">Total time (ms) </th>
-                                <th>Inspect</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            @foreach($requestInsurances as $requestInsurance)
-                                <tr>
-                                    <td>{{ $requestInsurance->id }}</td>
-                                    <td>{{ $requestInsurance->priority }}</td>
-                                    <td>{{ mb_strtoupper($requestInsurance->method) }}</td>
-                                    <td><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}" /></td>
-                                    <td>{{ urldecode($requestInsurance->url) }}</td>
-                                    <td><x-request-insurance-inline-print :content="$requestInsurance->getShortenedPayload()" /></td>
-                                    <td><x-request-insurance-status :requestInsurance="$requestInsurance" /></td>
-                                    <td>{{ $requestInsurance->state_changed_at }}</td>
-                                    <td>{{ $requestInsurance->retry_count }}</td>
-                                    <td>{{ $requestInsurance->retry_at }}</td>
-                                    <td>{{ $requestInsurance->created_at }}</td>
-                                    <td>{{ $requestInsurance->getTotalTime()}}</td>
-                                    <td>
-                                        <a href="{{ route('request-insurances.show', $requestInsurance) }}" class="btn btn-sm btn-outline-primary">Inspect</a>
-
-                                        @if ($requestInsurance->doesNotHaveState(State::COMPLETED) && $requestInsurance->doesNotHaveState(State::ABANDONED))
-                                            <form method="POST" action="{{ route('request-insurances.destroy', $requestInsurance) }}">
-                                                @csrf
-                                                <input type="hidden" name="_method" value="delete">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger">Abandon</button>
-                                            </form>
-                                        @endif
-
-                                        @if ($requestInsurance->isRetryable())
-                                            <form method="POST" action="{{ route('request-insurances.retry', $requestInsurance) }}">
-                                                @csrf
-                                                <button type="submit" class="btn btn-sm btn-outline-warning">Retry</button>
-                                            </form>
-                                        @endif
-
-                                        @if ($requestInsurance->hasState(State::PENDING))
-                                            <form method="POST" action="{{ route('request-insurances.unlock', $requestInsurance) }}">
-                                                @csrf
-                                                <button type="submit" class="btn btn-sm btn-outline-secondary">Unlock</button>
-                                            </form>
-                                        @endif
-                                    </td>
-                                </tr>
-                            @endforeach
-                            </tbody>
-                        </table>
-                        <div>
-                            <strong>NB: </strong>Priority is zero based, 0 is the highest priority
-                        </div>
-
-                        <div class="d-flex justify-content-center">
-                            {{ $requestInsurances->appends(Arr::except(Request::query(), "page"))->links() }}
-                        </div>
-                    </div>
+                        @if( ! $stage['branch'] && ! ($stages[$i + 1]['branch'] ?? true))
+                            <div class="select-none self-center text-slate-300 dark:text-slate-700" aria-hidden="true">→</div>
+                        @endif
+                    @endforeach
                 </div>
             </div>
-        </div>
+        </section>
+
+        <section aria-labelledby="requests-heading">
+            <h2 id="requests-heading" class="sr-only">Requests</h2>
+
+            {{-- Filters --}}
+            <form method="get" class="mb-4 flex flex-wrap items-center gap-2">
+                <input name="trace_id" value="{{ old('trace_id') }}" placeholder="trace id" class="h-10 w-44 rounded-xl border bg-white px-3.5 font-mono text-sm text-slate-950 shadow-xs placeholder:text-slate-400 dark:bg-slate-900 dark:text-white">
+                <input name="url" value="{{ old('url') }}" placeholder="url  %like%" class="h-10 w-56 rounded-xl border bg-white px-3.5 font-mono text-sm text-slate-950 shadow-xs placeholder:text-slate-400 dark:bg-slate-900 dark:text-white">
+                <input type="datetime-local" name="from" value="{{ old('from') }}" title="From" class="h-10 rounded-xl border bg-white px-3.5 font-mono text-sm text-slate-500 shadow-xs dark:bg-slate-900 dark:text-slate-400">
+                <input type="datetime-local" name="to" value="{{ old('to') }}" title="To" class="h-10 rounded-xl border bg-white px-3.5 font-mono text-sm text-slate-500 shadow-xs dark:bg-slate-900 dark:text-slate-400">
+                <div class="flex flex-wrap items-center gap-1.5">
+                    @foreach(State::getAll() as $state)
+                        <label class="cursor-pointer select-none">
+                            <input type="checkbox" name="{{ $state }}" @checked(old($state) == 'on') onchange="this.form.requestSubmit()" class="peer sr-only">
+                            <span class="chip chip-{{ State::getBootstrapColor($state) }} opacity-60 transition peer-checked:opacity-100 peer-checked:ring-2 peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-insurance">{{ ucfirst(strtolower($state)) }}</span>
+                        </label>
+                    @endforeach
+                </div>
+                <input type="hidden" name="per_page" value="{{ $perPage }}">
+                <div class="ml-auto flex gap-2">
+                    <button type="submit" class="h-10 rounded-xl bg-insurance px-4 text-sm font-bold text-white shadow-sm shadow-indigo-900/20 transition-transform hover:-translate-y-0.5 hover:bg-indigo-700 active:translate-y-0 motion-reduce:transform-none">Filter</button>
+                    <a href="{{ url()->current() }}" class="grid h-10 place-items-center rounded-xl px-4 text-sm font-bold text-slate-600 transition-colors hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800">Clear</a>
+                </div>
+            </form>
+
+            {{-- Holds the CSRF token + method for the bulk actions; row checkboxes and the bulk
+                 buttons associate with it via the form="ri-bulk" attribute (no nested forms). --}}
+            <form id="ri-bulk" method="POST">@csrf</form>
+
+            {{-- Bulk action bar — revealed by JS once at least one row is selected. --}}
+            <div id="ri-bulkbar" class="mb-3 hidden items-center gap-3 rounded-xl border border-indigo-300 bg-indigo-50 px-4 py-2.5 dark:border-indigo-900 dark:bg-indigo-950/40">
+                <span class="font-mono text-sm text-slate-600 dark:text-slate-300"><strong id="ri-selcount" class="text-slate-950 dark:text-white">0</strong> selected</span>
+                <div class="ml-auto flex items-center gap-2">
+                    <button type="submit" form="ri-bulk" formaction="{{ route('request-insurances.retry-selected') }}"
+                            onclick="return confirm('Retry the selected request insurances?')"
+                            class="h-8 rounded-lg bg-insurance px-3.5 text-xs font-bold text-white shadow-sm transition-colors hover:bg-indigo-700">Retry selected</button>
+                    <button type="submit" form="ri-bulk" formaction="{{ route('request-insurances.abandon-selected') }}"
+                            onclick="return confirm('Abandon the selected request insurances? Active requests will stop being processed.')"
+                            class="h-8 rounded-lg border border-red-500/40 px-3.5 text-xs font-bold text-red-700 transition-colors hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30">Abandon selected</button>
+                    <button type="button" id="ri-clearsel" class="rounded px-1 text-xs font-semibold text-slate-500 hover:text-slate-950 dark:text-slate-400 dark:hover:text-white">Clear</button>
+                </div>
+            </div>
+
+            {{-- Listing --}}
+            <div class="overflow-hidden rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+                @if($requestInsurances->isEmpty())
+                    <div class="px-6 py-16 text-center">
+                        <p class="text-base font-bold text-slate-900 dark:text-white">No requests found</p>
+                        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Nothing matches the current filters.</p>
+                    </div>
+                @else
+                    <div class="overflow-x-auto">
+                        <table class="w-full min-w-[72rem] text-left text-sm">
+                            <thead class="border-b bg-slate-50 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-slate-500 dark:bg-slate-950/60 dark:text-slate-400">
+                                <tr>
+                                    <th class="w-9 px-4 py-3.5"><input type="checkbox" id="ri-selectall" class="size-4 accent-insurance align-middle" title="Select all on this page"></th>
+                                    <th class="px-4 py-3.5">ID</th>
+                                    <th class="px-4 py-3.5">Pri</th>
+                                    <th class="px-4 py-3.5">Method</th>
+                                    <th class="px-4 py-3.5">Code</th>
+                                    <th class="px-4 py-3.5">Url</th>
+                                    <th class="px-4 py-3.5">State</th>
+                                    <th class="px-4 py-3.5">Attempts</th>
+                                    <th class="px-4 py-3.5">Next try</th>
+                                    <th class="px-4 py-3.5">Created</th>
+                                    <th class="px-4 py-3.5 text-right">ms</th>
+                                    <th class="px-4 py-3.5 text-right"><span class="sr-only">Actions</span></th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y font-mono">
+                                @foreach($requestInsurances as $requestInsurance)
+                                    <tr class="transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/50 [&>td]:whitespace-nowrap [&>td]:px-4 [&>td]:py-2.5">
+                                        <td>
+                                            @if($requestInsurance->doesNotHaveState(State::COMPLETED))
+                                                <input type="checkbox" name="ids[]" value="{{ $requestInsurance->id }}" form="ri-bulk" class="ri-select size-4 accent-insurance align-middle">
+                                            @endif
+                                        </td>
+                                        <td class="text-xs font-semibold text-slate-500 dark:text-slate-400">{{ $requestInsurance->id }}</td>
+                                        <td class="tabular-nums">{{ $requestInsurance->priority }}</td>
+                                        <td class="font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td>
+                                        <td><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}" /></td>
+                                        <td class="w-full max-w-0 truncate text-slate-500 dark:text-slate-400" title="{{ urldecode($requestInsurance->url) }}">{{ urldecode($requestInsurance->url) }}</td>
+                                        <td><x-request-insurance-status :requestInsurance="$requestInsurance" /></td>
+                                        <td class="tabular-nums">{{ $requestInsurance->retry_count }}</td>
+                                        <td class="text-xs"><x-request-insurance-timestamp :value="$requestInsurance->retry_at" /></td>
+                                        <td class="text-xs text-slate-500 dark:text-slate-400"><x-request-insurance-timestamp :value="$requestInsurance->created_at" /></td>
+                                        <td class="text-right tabular-nums text-slate-500 dark:text-slate-400">{{ $requestInsurance->getTotalTime() < 0 ? '·' : number_format($requestInsurance->getTotalTime()) }}</td>
+                                        <td>
+                                            <div class="grid grid-cols-[4.3rem_4.6rem_5rem_4.7rem] items-center gap-1.5">
+                                                @if($requestInsurance->isRetryable())
+                                                    <form method="POST" action="{{ route('request-insurances.retry', $requestInsurance) }}" class="w-full">@csrf
+                                                        <button type="submit" class="act border-amber-500/50 text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950/30">Retry</button>
+                                                    </form>
+                                                @else <span></span> @endif
+
+                                                @if($requestInsurance->hasState(State::PENDING))
+                                                    <form method="POST" action="{{ route('request-insurances.unlock', $requestInsurance) }}" class="w-full">@csrf
+                                                        <button type="submit" class="act border-slate-300 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">Unlock</button>
+                                                    </form>
+                                                @else <span></span> @endif
+
+                                                @if($requestInsurance->doesNotHaveState(State::COMPLETED) && $requestInsurance->doesNotHaveState(State::ABANDONED))
+                                                    <form method="POST" action="{{ route('request-insurances.destroy', $requestInsurance) }}" class="w-full" data-confirm="Abandon request insurance #{{ $requestInsurance->id }}?">@csrf
+                                                        <input type="hidden" name="_method" value="delete">
+                                                        <button type="submit" class="act border-red-500/40 text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30">Abandon</button>
+                                                    </form>
+                                                @else <span></span> @endif
+
+                                                <a href="{{ route('request-insurances.show', $requestInsurance) }}" class="act border-indigo-500/40 text-indigo-700 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-950/30">Inspect</a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+
+            <div class="mt-4 flex flex-wrap items-center justify-between gap-3 font-mono text-xs text-slate-500 dark:text-slate-400">
+                <span>priority is zero-based · 0 = highest</span>
+                <div class="flex items-center gap-4">
+                    <label class="flex items-center gap-2">rows
+                        <select onchange="const u=new URL(location); u.searchParams.set('per_page', this.value); u.searchParams.delete('cursor'); location = u;"
+                                class="h-9 rounded-lg border bg-white px-2 text-ink shadow-xs dark:bg-slate-900 dark:text-white">
+                            @foreach([25, 50, 100, 250, 500, 1000] as $size)
+                                <option value="{{ $size }}" @selected($perPage === $size)>{{ $size }}</option>
+                            @endforeach
+                        </select>
+                    </label>
+                    <span class="flex items-center gap-1.5">
+                        @if($requestInsurances->previousPageUrl())
+                            <a href="{{ $requestInsurances->previousPageUrl() }}" rel="prev" class="grid h-9 place-items-center rounded-lg border bg-white px-3 font-bold text-slate-700 transition-colors hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800">‹ Newer</a>
+                        @else
+                            <span aria-disabled="true" class="grid h-9 place-items-center rounded-lg border bg-white px-3 text-slate-300 dark:bg-slate-900 dark:text-slate-600">‹ Newer</span>
+                        @endif
+                        @if($requestInsurances->nextPageUrl())
+                            <a href="{{ $requestInsurances->nextPageUrl() }}" rel="next" class="grid h-9 place-items-center rounded-lg border bg-white px-3 font-bold text-slate-700 transition-colors hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800">Older ›</a>
+                        @else
+                            <span aria-disabled="true" class="grid h-9 place-items-center rounded-lg border bg-white px-3 text-slate-300 dark:bg-slate-900 dark:text-slate-600">Older ›</span>
+                        @endif
+                    </span>
+                </div>
+            </div>
+        </section>
     </div>
+@endsection
+
+@section('scripts')
+<script>
+    // Fill the lifecycle strip counts.
+    fetch('{{ route('request-insurances.monitor_segmented') }}')
+        .then(r => r.json())
+        .then(counts => Object.entries(counts).forEach(([state, n]) => {
+            const el = document.getElementById('count-' + state);
+            if (el) el.textContent = Number(n).toLocaleString();
+        }))
+        .catch(() => document.querySelectorAll('[id^="count-"]').forEach(el => el.textContent = '–'));
+
+    // Row selection + bulk action bar.
+    (function () {
+        const bar = document.getElementById('ri-bulkbar');
+        const countEl = document.getElementById('ri-selcount');
+        const selectAll = document.getElementById('ri-selectall');
+        const boxes = () => Array.from(document.querySelectorAll('.ri-select'));
+
+        if (!selectAll) return;
+
+        function sync() {
+            const checked = boxes().filter(b => b.checked).length;
+            countEl.textContent = checked;
+            bar.classList.toggle('hidden', checked === 0);
+            bar.classList.toggle('flex', checked !== 0);
+            const all = boxes();
+            selectAll.checked = all.length > 0 && checked === all.length;
+            selectAll.indeterminate = checked > 0 && checked < all.length;
+        }
+        selectAll.addEventListener('change', () => { boxes().forEach(b => b.checked = selectAll.checked); sync(); });
+        boxes().forEach(b => b.addEventListener('change', sync));
+        document.getElementById('ri-clearsel').addEventListener('click', () => { boxes().forEach(b => b.checked = false); sync(); });
+        sync();
+    })();
+</script>
 @endsection

--- a/publishable/views/index.blade.php
+++ b/publishable/views/index.blade.php
@@ -19,14 +19,17 @@
     @endphp
 
     <div class="space-y-8">
-        <section class="max-w-3xl">
-            <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-insurance">Request pipeline</p>
-            <h1 class="text-4xl font-black tracking-[-0.04em] text-slate-950 sm:text-5xl dark:text-white">Every request lands.<br><span class="text-slate-400 dark:text-slate-500">Or you learn why.</span></h1>
-            <p class="mt-5 max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300">Guaranteed asynchronous HTTP delivery — with retries, edits, approvals, and a full audit trail for every request.</p>
-        </section>
+        {{-- On wide screens the lifecycle strip sits beside the hero instead of
+             below it, so the listing starts a full section higher. --}}
+        <section class="grid items-center gap-6 xl:grid-cols-[minmax(24rem,0.9fr)_minmax(0,2.1fr)]">
+            <div class="max-w-3xl">
+                <p class="mb-3 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-insurance">Request pipeline</p>
+                <h1 class="text-3xl font-black tracking-[-0.04em] text-slate-950 sm:text-4xl dark:text-white">Every request lands.<br><span class="text-slate-400 dark:text-slate-500">Or you learn why.</span></h1>
+                <p class="mt-4 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">Guaranteed asynchronous HTTP delivery — with retries, edits, approvals, and a full audit trail for every request.</p>
+            </div>
 
-        {{-- Lifecycle flow strip: success path, then a divergent exceptions branch. --}}
-        <section aria-label="Requests per state" class="overflow-hidden rounded-2xl border bg-white p-1 shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+            {{-- Lifecycle flow strip: success path, then a divergent exceptions branch. --}}
+            <section aria-label="Requests per state" class="overflow-hidden rounded-2xl border bg-white p-1 shadow-sm shadow-slate-900/5 dark:bg-slate-900">
             <div class="flex items-stretch overflow-x-auto">
                 <div class="flex flex-1 items-stretch">
                     @foreach($stages as $i => $stage)
@@ -44,8 +47,9 @@
                             <div class="select-none self-center text-slate-300 dark:text-slate-700" aria-hidden="true">→</div>
                         @endif
                     @endforeach
+                    </div>
                 </div>
-            </div>
+            </section>
         </section>
 
         <section aria-labelledby="requests-heading">

--- a/publishable/views/index.blade.php
+++ b/publishable/views/index.blade.php
@@ -103,12 +103,13 @@
                     </div>
                 @else
                     <div class="overflow-x-auto">
-                        <table class="w-full min-w-[72rem] text-left text-sm">
+                        {{-- No minimum table width: cells wrap instead of forcing a horizontal scrollbar. --}}
+                        <table class="w-full text-left text-sm">
                             <thead class="border-b bg-slate-50 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-slate-500 dark:bg-slate-950/60 dark:text-slate-400">
                                 <tr>
                                     <th class="w-9 px-4 py-3.5"><input type="checkbox" id="ri-selectall" class="size-4 accent-insurance align-middle" title="Select all on this page"></th>
                                     <th class="px-4 py-3.5">ID</th>
-                                    <th class="px-4 py-3.5">Pri</th>
+                                    <th class="px-4 py-3.5">Priority</th>
                                     <th class="px-4 py-3.5">Method</th>
                                     <th class="px-4 py-3.5">Code</th>
                                     <th class="px-4 py-3.5">Url</th>
@@ -122,22 +123,22 @@
                             </thead>
                             <tbody class="divide-y font-mono">
                                 @foreach($requestInsurances as $requestInsurance)
-                                    <tr class="transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/50 [&>td]:whitespace-nowrap [&>td]:px-4 [&>td]:py-2.5">
+                                    <tr class="transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/50 [&>td]:px-4 [&>td]:py-2.5">
                                         <td>
                                             @if($requestInsurance->doesNotHaveState(State::COMPLETED))
                                                 <input type="checkbox" name="ids[]" value="{{ $requestInsurance->id }}" form="ri-bulk" class="ri-select size-4 accent-insurance align-middle">
                                             @endif
                                         </td>
-                                        <td class="text-xs font-semibold text-slate-500 dark:text-slate-400">{{ $requestInsurance->id }}</td>
-                                        <td class="tabular-nums">{{ $requestInsurance->priority }}</td>
-                                        <td class="font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td>
-                                        <td><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}" /></td>
-                                        <td class="w-full min-w-[20rem] max-w-0 !whitespace-normal text-slate-500 dark:text-slate-400" title="{{ urldecode($requestInsurance->url) }}"><span class="line-clamp-2 break-all">{{ urldecode($requestInsurance->url) }}</span></td>
-                                        <td><x-request-insurance-status :requestInsurance="$requestInsurance" /></td>
-                                        <td class="tabular-nums">{{ $requestInsurance->retry_count }}</td>
-                                        <td class="text-xs"><x-request-insurance-timestamp :value="$requestInsurance->retry_at" /></td>
-                                        <td class="text-xs text-slate-500 dark:text-slate-400"><x-request-insurance-timestamp :value="$requestInsurance->created_at" /></td>
-                                        <td class="text-right tabular-nums text-slate-500 dark:text-slate-400">{{ $requestInsurance->getTotalTime() < 0 ? '·' : number_format($requestInsurance->getTotalTime()) }}</td>
+                                        <td class="whitespace-nowrap text-xs font-semibold text-slate-500 dark:text-slate-400">{{ $requestInsurance->id }}</td>
+                                        <td class="whitespace-nowrap tabular-nums">{{ $requestInsurance->priority }}</td>
+                                        <td class="whitespace-nowrap font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td>
+                                        <td class="whitespace-nowrap"><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}" /></td>
+                                        <td class="w-full min-w-[16rem] max-w-0 text-slate-500 dark:text-slate-400" title="{{ urldecode($requestInsurance->url) }}"><span class="line-clamp-2 break-all">{{ urldecode($requestInsurance->url) }}</span></td>
+                                        <td class="whitespace-nowrap"><x-request-insurance-status :requestInsurance="$requestInsurance" /></td>
+                                        <td class="whitespace-nowrap tabular-nums">{{ $requestInsurance->retry_count }}</td>
+                                        <td class="min-w-[7.5rem] text-xs"><x-request-insurance-timestamp :value="$requestInsurance->retry_at" /></td>
+                                        <td class="min-w-[7.5rem] text-xs text-slate-500 dark:text-slate-400"><x-request-insurance-timestamp :value="$requestInsurance->created_at" /></td>
+                                        <td class="whitespace-nowrap text-right tabular-nums text-slate-500 dark:text-slate-400">{{ $requestInsurance->getTotalTime() < 0 ? '·' : number_format($requestInsurance->getTotalTime()) }}</td>
                                         <td>
                                             <div class="grid grid-cols-[4.3rem_4.6rem_5rem_4.7rem] items-center gap-1.5">
                                                 @if($requestInsurance->isRetryable())

--- a/publishable/views/index.blade.php
+++ b/publishable/views/index.blade.php
@@ -128,7 +128,7 @@
                                         <td class="tabular-nums">{{ $requestInsurance->priority }}</td>
                                         <td class="font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td>
                                         <td><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}" /></td>
-                                        <td class="w-full max-w-0 truncate text-slate-500 dark:text-slate-400" title="{{ urldecode($requestInsurance->url) }}">{{ urldecode($requestInsurance->url) }}</td>
+                                        <td class="w-full min-w-[20rem] max-w-0 !whitespace-normal text-slate-500 dark:text-slate-400" title="{{ urldecode($requestInsurance->url) }}"><span class="line-clamp-2 break-all">{{ urldecode($requestInsurance->url) }}</span></td>
                                         <td><x-request-insurance-status :requestInsurance="$requestInsurance" /></td>
                                         <td class="tabular-nums">{{ $requestInsurance->retry_count }}</td>
                                         <td class="text-xs"><x-request-insurance-timestamp :value="$requestInsurance->retry_at" /></td>

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -117,10 +117,11 @@
             (root || document).querySelectorAll('time[data-ts]').forEach(el => {
                 const then = Date.parse(el.dataset.ts);
                 if (isNaN(then)) return;
-                // The viewer's own timezone, with the zone named; recent values read as relative.
-                el.title = timestampFormat.format(then);
+                // The viewer's own timezone, with the zone named; recent values also show the time since.
+                const absolute = timestampFormat.format(then);
+                el.title = absolute;
                 const delta = Date.now() - then;
-                el.textContent = Math.abs(delta) < 86400000 ? relativeTime(delta) : timestampFormat.format(then);
+                el.textContent = Math.abs(delta) < 86400000 ? `${absolute} (${relativeTime(delta)})` : absolute;
             });
         }
         document.addEventListener('DOMContentLoaded', () => {

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -1,62 +1,134 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full scheme-light dark:scheme-dark">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>RequestInsurance</title>
-
-    <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
-
-    <!-- Stylesheets -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/night-owl.min.css">
-
-    <!-- Scripts -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
-    <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/json.min.js"></script>
-
-    <style>
-        .table-vertical tr td:first-child {
-            width: 1%;
-            white-space: nowrap;
-            padding-right: 0.4em;
-            font-weight: bold;
-            vertical-align: top;
-        }
-
-        pre {
-            white-space: pre-wrap;       /* Since CSS 2.1 */
-            white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-            white-space: -pre-wrap;      /* Opera 4-6 */
-            white-space: -o-pre-wrap;    /* Opera 7 */
-            word-wrap: break-word;       /* Internet Explorer 5.5+ */
-            word-break: break-word;
-            margin-bottom: 0px;
-            border-radius: 10px;
-        }
-
-        .check-lg {
-            transform: scale(1.5);
-            -webkit-transform: scale(1.5);
-            margin-right: 0.45em !important;
-            margin-left: 0.2em !important;
-        }
-    </style>
-</head>
-<body class="bg-light">
-    <div class="container-fluid col-12">
-        @yield('content')
-    </div>
+    <title>@yield('title', 'Request Insurance')</title>
 
     <script>
+        const colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+        const applyColorScheme = event => document.documentElement.classList.toggle('dark', event.matches);
+        applyColorScheme(colorScheme);
+        colorScheme.addEventListener('change', applyColorScheme);
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss-browser/4.3.2/index.global.min.js" integrity="sha512-wf0Z7EtuTFwP09V3hWIeyfzBKDlqjvwls1kjiGH8F2xB6hwD04IXyOyCADqlIyr+HtwgAq7CtPMll7eI49Ab8Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <style type="text/tailwindcss">
+        @custom-variant dark (&:where(.dark, .dark *));
+
+        @theme {
+            --color-canvas: #f4f7fb;
+            --color-ink: #172033;
+            --color-insurance: #4f46e5;
+            --color-terminal: #101828;
+            --font-sans: "Aptos", "Inter", ui-sans-serif, system-ui, sans-serif;
+            --font-mono: "Berkeley Mono", "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+        }
+
+        @layer base {
+            * {
+                border-color: var(--color-slate-200);
+            }
+
+            body {
+                @apply bg-canvas text-ink antialiased dark:bg-slate-950 dark:text-slate-100;
+            }
+
+            button, a, input, select {
+                @apply focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-insurance;
+            }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            * {
+                border-color: var(--color-slate-800);
+            }
+        }
+
+        @layer components {
+            /* State chip; suffix matches State::getBootstrapColor / HttpCode::badgeColor. */
+            .chip {
+                @apply inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold ring-1 ring-inset;
+            }
+            .chip-secondary { @apply bg-slate-100 text-slate-600 ring-slate-500/20 dark:bg-slate-800 dark:text-slate-300; }
+            .chip-info      { @apply bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-950/50 dark:text-blue-300; }
+            .chip-success   { @apply bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/50 dark:text-emerald-300; }
+            .chip-danger    { @apply bg-red-50 text-red-700 ring-red-600/20 dark:bg-red-950/50 dark:text-red-300; }
+            .chip-warning   { @apply bg-amber-50 text-amber-700 ring-amber-600/20 dark:bg-amber-950/50 dark:text-amber-300; }
+            .chip-primary   { @apply bg-indigo-50 text-indigo-700 ring-indigo-600/20 dark:bg-indigo-950/50 dark:text-indigo-300; }
+
+            /* Text tone for the lifecycle-strip counters; dots piggyback via bg-current. */
+            .tone-secondary { @apply text-slate-500 dark:text-slate-400; }
+            .tone-info      { @apply text-blue-600 dark:text-blue-400; }
+            .tone-success   { @apply text-emerald-600 dark:text-emerald-400; }
+            .tone-danger    { @apply text-red-600 dark:text-red-400; }
+            .tone-warning   { @apply text-amber-600 dark:text-amber-400; }
+            .tone-primary   { @apply text-indigo-600 dark:text-indigo-400; }
+
+            /* Row action button: consistent size so column slots stay aligned. */
+            .act {
+                @apply inline-flex h-7 w-full cursor-pointer items-center justify-center whitespace-nowrap rounded-lg border text-xs font-semibold transition-colors;
+            }
+
+            /* Vertical key/value tables used on the inspect pages. */
+            .kv td { @apply border-b px-3 py-2.5 align-top; }
+            .kv tr:last-child td { @apply border-0; }
+            .kv td:first-child { @apply w-px whitespace-nowrap pr-6 font-sans text-xs font-bold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400; }
+        }
+    </style>
+
+    {{-- JSON syntax highlighting inside always-dark terminal blocks, pinned from cdnjs. --}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" integrity="sha512-rO+olRTkcf304DQBxSWxln8JXCzTHlKnIdnMUwYvQa9/Jd4cQaNkItIUj6Z4nvW1dqK0SKXLbn9h4KwZTNtAyw==" crossorigin="anonymous" referrerpolicy="no-referrer">
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/languages/json.min.js" integrity="sha512-f2/ljYb/tG4fTHu6672tyNdoyhTIpt4N1bGrBE8ZjwIgrjDCd+rljLpWCZ2Vym9PBWQy2Tl9O22Pp2rMOMvH4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body class="min-h-full">
+    <header class="border-b bg-white/90 backdrop-blur dark:bg-slate-950/90">
+        <div class="mx-auto flex max-w-screen-2xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+            <a href="{{ route('request-insurances.index') }}" class="group flex items-center gap-3 rounded-lg">
+                <span class="grid size-9 place-items-center rounded-xl bg-terminal text-sm font-black tracking-tight text-white shadow-sm shadow-slate-900/20 transition-transform group-hover:-rotate-3 dark:bg-white dark:text-slate-950">⇄</span>
+                <span>
+                    <span class="block text-sm font-bold tracking-tight">Request Insurance</span>
+                    <span class="block text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Delivery pipeline</span>
+                </span>
+            </a>
+            <a href="/" class="rounded-lg px-3 py-2 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white">Back to application</a>
+        </div>
+    </header>
+
+    <main class="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+        @yield('content')
+    </main>
+
+    <script>
+        // Format timestamps: show a relative duration when recent, keep the absolute value on hover.
+        function relativeTime(deltaMs) {
+            const abs = Math.abs(deltaMs);
+            const s = Math.round(abs / 1000), m = Math.round(s / 60), h = Math.round(m / 60);
+            const t = s < 60 ? s + 's' : m < 60 ? m + 'm' : h + 'h';
+            return deltaMs >= 0 ? t + ' ago' : 'in ' + t;
+        }
+        function upgradeTimestamps(root) {
+            (root || document).querySelectorAll('time[data-ts]').forEach(el => {
+                const then = Date.parse(el.dataset.ts);
+                if (isNaN(then)) return;
+                const delta = Date.now() - then;
+                if (Math.abs(delta) < 86400000) el.textContent = relativeTime(delta); // within 24h
+            });
+        }
         document.addEventListener('DOMContentLoaded', () => {
-            hljs.highlightAll();
+            if (window.hljs) hljs.highlightAll();
+            upgradeTimestamps();
+
+            document.querySelectorAll('form[data-confirm]').forEach(form => {
+                form.addEventListener('submit', event => {
+                    if (!window.confirm(form.dataset.confirm)) {
+                        event.preventDefault();
+                    }
+                });
+            });
         });
     </script>
+    @yield('scripts')
 </body>
 </html>

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -84,7 +84,7 @@
 </head>
 <body class="min-h-full">
     <header class="border-b bg-white/90 backdrop-blur dark:bg-slate-950/90">
-        <div class="mx-auto flex max-w-[96rem] min-[1800px]:max-w-[120rem] items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <div class="mx-auto flex max-w-[96rem] min-[1800px]:max-w-none min-[1800px]:px-12 items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
             <a href="{{ route('request-insurances.index') }}" class="group flex items-center gap-3 rounded-lg">
                 <span class="grid size-9 place-items-center rounded-xl bg-terminal text-sm font-black tracking-tight text-white shadow-sm shadow-slate-900/20 transition-transform group-hover:-rotate-3 dark:bg-white dark:text-slate-950">⇄</span>
                 <span>
@@ -96,7 +96,7 @@
         </div>
     </header>
 
-    <main class="mx-auto w-full max-w-[96rem] min-[1800px]:max-w-[120rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+    <main class="mx-auto w-full max-w-[96rem] min-[1800px]:max-w-none min-[1800px]:px-12 px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
         @yield('content')
     </main>
 

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -108,12 +108,19 @@
             const t = s < 60 ? s + 's' : m < 60 ? m + 'm' : h + 'h';
             return deltaMs >= 0 ? t + ' ago' : 'in ' + t;
         }
+        const timestampFormat = new Intl.DateTimeFormat('sv-SE', {
+            year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit', second: '2-digit',
+            timeZoneName: 'short',
+        });
         function upgradeTimestamps(root) {
             (root || document).querySelectorAll('time[data-ts]').forEach(el => {
                 const then = Date.parse(el.dataset.ts);
                 if (isNaN(then)) return;
+                // The viewer's own timezone, with the zone named; recent values read as relative.
+                el.title = timestampFormat.format(then);
                 const delta = Date.now() - then;
-                if (Math.abs(delta) < 86400000) el.textContent = relativeTime(delta); // within 24h
+                el.textContent = Math.abs(delta) < 86400000 ? relativeTime(delta) : timestampFormat.format(then);
             });
         }
         document.addEventListener('DOMContentLoaded', () => {

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -84,7 +84,7 @@
 </head>
 <body class="min-h-full">
     <header class="border-b bg-white/90 backdrop-blur dark:bg-slate-950/90">
-        <div class="mx-auto flex max-w-screen-2xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <div class="mx-auto flex max-w-[96rem] min-[1800px]:max-w-[110rem] items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
             <a href="{{ route('request-insurances.index') }}" class="group flex items-center gap-3 rounded-lg">
                 <span class="grid size-9 place-items-center rounded-xl bg-terminal text-sm font-black tracking-tight text-white shadow-sm shadow-slate-900/20 transition-transform group-hover:-rotate-3 dark:bg-white dark:text-slate-950">⇄</span>
                 <span>
@@ -96,7 +96,7 @@
         </div>
     </header>
 
-    <main class="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+    <main class="mx-auto w-full max-w-[96rem] min-[1800px]:max-w-[110rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
         @yield('content')
     </main>
 

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -84,7 +84,7 @@
 </head>
 <body class="min-h-full">
     <header class="border-b bg-white/90 backdrop-blur dark:bg-slate-950/90">
-        <div class="mx-auto flex max-w-[96rem] min-[1800px]:max-w-[110rem] items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <div class="mx-auto flex max-w-[96rem] min-[1800px]:max-w-[120rem] items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
             <a href="{{ route('request-insurances.index') }}" class="group flex items-center gap-3 rounded-lg">
                 <span class="grid size-9 place-items-center rounded-xl bg-terminal text-sm font-black tracking-tight text-white shadow-sm shadow-slate-900/20 transition-transform group-hover:-rotate-3 dark:bg-white dark:text-slate-950">⇄</span>
                 <span>
@@ -96,7 +96,7 @@
         </div>
     </header>
 
-    <main class="mx-auto w-full max-w-[96rem] min-[1800px]:max-w-[110rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+    <main class="mx-auto w-full max-w-[96rem] min-[1800px]:max-w-[120rem] px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
         @yield('content')
     </main>
 

--- a/publishable/views/layouts/master.blade.php
+++ b/publishable/views/layouts/master.blade.php
@@ -78,7 +78,7 @@
     </style>
 
     {{-- JSON syntax highlighting inside always-dark terminal blocks, pinned from cdnjs. --}}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" integrity="sha512-rO+olRTkcf304DQBxSWxln8JXCzTHlKnIdnMUwYvQa9/Jd4cQaNkItIUj6Z4nvW1dqK0SKXLbn9h4KwZTNtAyw==" crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/tokyo-night-dark.min.css" integrity="sha512-dSQLLtgaq2iGigmy9xowRshaMzUHeiIUTvJW/SkUpb1J+ImXOPNGAI7ZC8V5/PiN/XN83B8uIk4qET7AMhdC5Q==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/languages/json.min.js" integrity="sha512-f2/ljYb/tG4fTHu6672tyNdoyhTIpt4N1bGrBE8ZjwIgrjDCd+rljLpWCZ2Vym9PBWQy2Tl9O22Pp2rMOMvH4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>

--- a/publishable/views/show.blade.php
+++ b/publishable/views/show.blade.php
@@ -116,6 +116,13 @@
                     <table class="kv w-full font-mono text-[13px]">
                         <tbody>
                             <tr><td>Id</td><td>{{ $requestInsurance->id }}</td></tr>
+                            <tr><td>Trace id</td><td>
+                                @if(filled($requestInsurance->trace_id))
+                                    <a href="{{ route('request-insurances.index', ['trace_id' => $requestInsurance->trace_id]) }}" title="Show all requests with this trace id" class="break-all rounded text-insurance hover:underline">{{ $requestInsurance->trace_id }}</a>
+                                @else
+                                    <span class="text-slate-400 dark:text-slate-500">—</span>
+                                @endif
+                            </td></tr>
                             <tr><td>Priority</td><td>{{ $requestInsurance->priority }}</td></tr>
                             <tr><td>Method</td><td class="font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td></tr>
                             <tr><td>Url (decoded)</td><td class="break-all">{{ urldecode($requestInsurance->url) }}</td></tr>

--- a/publishable/views/show.blade.php
+++ b/publishable/views/show.blade.php
@@ -1,443 +1,328 @@
-<?php
-use \Cego\RequestInsurance\Enums\State;
-use Jfcherng\Diff\DiffHelper;
+<?php use Cego\RequestInsurance\Enums\State; ?>
+@extends('request-insurance::layouts.master')
 
-?>
-@extends("request-insurance::layouts.master")
+@section('title', 'Request #' . $requestInsurance->id . ' · Request Insurance')
 
-@section("content")
-
+@section('content')
     @php
         if(!function_exists('getEditErrorMessage')){
             function getEditErrorMessage($editId, $field) {
                 $requestInsuranceEdit = Session::get('requestInsuranceEdit');
                 $requestErrors = Session::get('requestErrors');
-                if ( empty($requestInsuranceEdit)){
-                    return "";
-                }
-                if ($requestInsuranceEdit->id != $editId){
-                    return "";
-                }
-                if ( empty($requestErrors[$field])){
-                    return "";
-                }
+                if ( empty($requestInsuranceEdit)){ return ""; }
+                if ($requestInsuranceEdit->id != $editId){ return ""; }
+                if ( empty($requestErrors[$field])){ return ""; }
                 return $requestErrors[$field];
             }
         }
     @endphp
-    <div class="container-flex mt-5 col-12">
-        <div class="row">
-            <div class="col-12">
-                <h1 class="">Inspecting request insurance <strong>#{{ $requestInsurance->id }}</strong> <x-request-insurance-status :requestInsurance="$requestInsurance" /></h1>
-            </div>
-            <!-- Request -->
-            <div class="col-6">
-                <div class="card">
-                    <div class="card-body">
-                        <div class="card-title text-center">
-                            <h3>Request</h3>
-                            @if ($requestInsurance->doesNotHaveState(State::COMPLETED) && $requestInsurance->doesNotHaveState(State::ABANDONED))
-                                <div class="mt-2">
-                                    <form method="POST" action="{{ route('request-insurance-edits.create', $requestInsurance) }}">
-                                        @csrf
-                                        <input type="hidden" name="_method" value="post">
-                                        <button class="btn btn-primary" type="submit">Edit</button>
-                                    </form>
-                                </div>
-                            @endif
-                            @php
-                                $appliedEdits = $requestInsurance->edits()->where('applied_at', '<>', null);
-                            @endphp
-                            @if($appliedEdits->count() > 0)
-                                <div class="mt-2">
-                                    <form method="GET" action="{{ route('request-insurances.edit-history', $requestInsurance) }}">
-                                        <input type="hidden" name="_method" value="get">
-                                        <button class="btn btn-warning" type="submit">History</button>
-                                    </form>
-                                </div>
-                            @endif
-                            <hr>
-                        </div>
-                        <div class="card-text">
-                            <table class="table-hover w-100 table-vertical table-striped">
-                                <tbody>
-                                <tr>
-                                    <td>RequestInsurance Id:</td>
-                                    <td>{{ $requestInsurance->id }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Priority:</td>
-                                    <td>{{ $requestInsurance->priority }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Method:</td>
-                                    <td>{{ mb_strtoupper($requestInsurance->method) }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Url (decoded):</td>
-                                    <td>{{ urldecode($requestInsurance->url) }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Url</td>
-                                    <td>{{ $requestInsurance->url }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Payload:</td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->getPayloadWithMaskingApplied()"/></td>
-                                </tr>
-                                <tr>
-                                    <td>Headers:</td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->getHeadersWithMaskingApplied()"/></td>
-                                </tr>
-                                <tr>
-                                    <td>Timings: </td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->timings"/></td>
-                                </tr>
-                                <tr>
-                                    <td>Next attempt at:</td>
-                                    <td>{{ $requestInsurance->retry_at }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Attempts:</td>
-                                    <td>{{ $requestInsurance->retry_count }}</td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+
+    <style>
+        @keyframes riFlash { 0%{background:transparent} 45%{background:rgba(79,70,229,.18)} 100%{background:transparent} }
+        .backgroundAnimated{ animation: riFlash .8s ease-in-out; }
+
+        /* Theme-aware diff viewer (markup produced by jfcherng/php-diff). */
+        :root{
+            --diff-ink:#172033; --diff-soft:#5c6779; --diff-line:#e2e8f0; --diff-surface:#f8fafc;
+            --diff-del:#dc2626; --diff-ins:#059669;
+        }
+        @media (prefers-color-scheme: dark){
+            :root{
+                --diff-ink:#e2e8f0; --diff-soft:#94a3b8; --diff-line:#1e293b; --diff-surface:#020617;
+                --diff-del:#f87171; --diff-ins:#34d399;
+            }
+        }
+        .diff-wrapper.diff{
+            width:100%; border-collapse:collapse; background:transparent; color:var(--diff-ink);
+            font-family:var(--font-mono); font-size:12px; line-height:1.55; word-break:break-all;
+            border:1px solid var(--diff-line); border-radius:.5rem; overflow:hidden;
+        }
+        .diff-wrapper.diff thead th{
+            background:var(--diff-surface); color:var(--diff-soft); white-space:nowrap;
+            font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.06em;
+            text-align:left; padding:.4rem .6rem; border-bottom:1px solid var(--diff-line);
+        }
+        .diff-wrapper.diff td, .diff-wrapper.diff th{ padding:.12rem .6rem; vertical-align:top; border:0; }
+        .diff-wrapper.diff tbody th{
+            width:1%; white-space:nowrap; text-align:right; font-weight:400; user-select:none;
+            color:var(--diff-soft); background:var(--diff-surface);
+        }
+        .diff-wrapper.diff tbody th.sign{ padding:0 .4rem; text-align:center; }
+        .diff-wrapper.diff tbody th.sign.del{ color:var(--diff-del); }
+        .diff-wrapper.diff tbody th.sign.ins{ color:var(--diff-ins); }
+        .diff-wrapper.diff td.old, .diff-wrapper.diff td.rep{ background:color-mix(in srgb, var(--diff-del) 9%, transparent); }
+        .diff-wrapper.diff td.new{ background:color-mix(in srgb, var(--diff-ins) 10%, transparent); }
+        .diff-wrapper.diff td.none{ background:transparent; }
+        .diff-wrapper.diff .change-eq td{ color:var(--diff-soft); }
+        .diff-wrapper.diff tbody.skipped td, .diff-wrapper.diff tbody.skipped th{
+            background:var(--diff-surface); color:var(--diff-soft); text-align:center;
+        }
+        /* inline word/char-level changes */
+        .diff-wrapper.diff.diff-html .change ins{
+            text-decoration:none; border-radius:2px; padding:0 1px;
+            background:color-mix(in srgb, var(--diff-ins) 30%, transparent);
+            color:color-mix(in srgb, var(--diff-ins) 75%, var(--diff-ink));
+        }
+        .diff-wrapper.diff.diff-html .change del{
+            text-decoration:none; border-radius:2px; padding:0 1px;
+            background:color-mix(in srgb, var(--diff-del) 30%, transparent);
+            color:color-mix(in srgb, var(--diff-del) 75%, var(--diff-ink));
+        }
+    </style>
+
+    @php
+        $btnPrimary = 'inline-flex h-9 cursor-pointer items-center justify-center rounded-xl bg-insurance px-4 text-sm font-bold text-white shadow-sm shadow-indigo-900/20 transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-insurance';
+        $btnDanger  = 'inline-flex h-9 cursor-pointer items-center justify-center rounded-xl border border-red-500/40 px-4 text-sm font-bold text-red-700 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-40 dark:text-red-400 dark:hover:bg-red-950/30';
+        $btnGhost   = 'inline-flex h-9 cursor-pointer items-center justify-center rounded-xl border bg-white px-4 text-sm font-bold text-slate-700 shadow-sm transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800';
+        $editInput  = 'w-full rounded-xl border bg-white px-3 py-2 font-mono text-xs text-slate-950 shadow-xs disabled:opacity-60 dark:bg-slate-950 dark:text-white';
+    @endphp
+
+    <div class="space-y-6">
+        <nav aria-label="Breadcrumb" class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+            <a href="{{ route('request-insurances.index') }}" class="rounded hover:text-insurance">Pipeline</a>
+            <span aria-hidden="true">/</span>
+            <span class="font-medium text-slate-900 dark:text-white">Request #{{ $requestInsurance->id }}</span>
+        </nav>
+
+        <header class="flex flex-wrap items-end justify-between gap-4 border-b pb-6">
+            <div>
+                <p class="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-insurance">Inspection</p>
+                <div class="mt-2 flex flex-wrap items-center gap-3">
+                    <h1 class="text-3xl font-black tracking-[-0.04em] text-slate-950 sm:text-4xl dark:text-white">Request #{{ $requestInsurance->id }}</h1>
+                    <x-request-insurance-status :requestInsurance="$requestInsurance" />
                 </div>
             </div>
-
-            <!-- Response -->
-            <div class="col-6">
-                <div class="card">
-                    <div class="card-body">
-                        <div class="card-title text-center">
-                            <h3>Response:</h3>
-                            <hr>
-                        </div>
-                        <div class="card-text">
-                            <table class="table-hover w-100 table-vertical table-striped">
-                                <tbody>
-                                <tr>
-                                    <td>Response code:</td>
-                                    <td style="max-width:1px"><h4><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}"/></h4></td>
-                                </tr>
-                                <tr>
-                                    <td>Response headers:</td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->response_headers"/></td>
-                                </tr>
-                                <tr>
-                                    <td>Response body</td>
-                                    <td style="max-width:1px"><x-request-insurance-pretty-print :content="$requestInsurance->response_body"/></td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
+            <div class="flex flex-wrap gap-2">
+                @if ($requestInsurance->doesNotHaveState(State::COMPLETED) && $requestInsurance->doesNotHaveState(State::ABANDONED))
+                    <form method="POST" action="{{ route('request-insurance-edits.create', $requestInsurance) }}">@csrf
+                        <button class="{{ $btnPrimary }}" type="submit">Edit request</button>
+                    </form>
+                @endif
+                @php $appliedEdits = $requestInsurance->edits()->where('applied_at', '<>', null); @endphp
+                @if($appliedEdits->count() > 0)
+                    <a href="{{ route('request-insurances.edit-history', $requestInsurance) }}" class="{{ $btnGhost }}">Edit history</a>
+                @endif
             </div>
-            <!-- Edit(s) -->
-            <style>
-                @-o-keyframes fadeIt {
-                    0%   { background-color: #FFFFFF; }
-                    50%  { background-color: #AD301B; }
-                    100% { background-color: #FFFFFF; }
-                }
-                @keyframes fadeIt {
-                    0%   { background-color: #FFFFFF; }
-                    50%  { background-color: #AD301B; }
-                    100% { background-color: #FFFFFF; }
-                }
+        </header>
 
-                .backgroundAnimated{
-                    background-image:none !important;
-                    -o-animation: fadeIt .5s ease-in-out;
-                    animation: fadeIt .5s ease-in-out;
-                }
-                <?= DiffHelper::getStyleSheet(); ?>
-            </style>
-            @php
-                $pendingEdits = $requestInsurance->edits()->where('applied_at', null)->orderBy('updated_at', 'DESC');
-            @endphp
-            @if($pendingEdits->count() > 0)
-                <div class="col-12 mt-2">
-                    <div class="card">
-                        <div class="card-body">
-                            <div class="card-title text-center">
-                                <h3>Edits
-                                    <span class="custom-control custom-switch">
-                                    <input type="checkbox" checked class="custom-control-input" id="toggleCollapseEdits" data-toggle="collapse" data-target="#collapseEdits">
-                                    <label class="custom-control-label" for="toggleCollapseEdits"></label>
-                                </span>
-                                </h3>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="collapse show" id="collapseEdits">
-                        @foreach($pendingEdits->get() as $edit)
-                            @php
-                                $canModifyEdit = $edit->applied_at == null && $edit->admin_user == $user;
-                                $canApproveEdit = $edit->applied_at == null && ! $canModifyEdit;
-                                $canApplyEdit = $edit->applied_at == null && $edit->approvals->count() >= $edit->required_number_of_approvals && $canModifyEdit;
-                            @endphp
+        <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            {{-- Request --}}
+            <section aria-labelledby="request-heading" class="overflow-hidden rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+                <div class="border-b px-5 py-4 sm:px-6">
+                    <p class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.16em] text-slate-400">Outbound</p>
+                    <h2 id="request-heading" class="mt-1 text-lg font-extrabold text-slate-950 dark:text-white">Request</h2>
+                </div>
+                <div class="p-5 sm:p-6">
+                    <table class="kv w-full font-mono text-[13px]">
+                        <tbody>
+                            <tr><td>Id</td><td>{{ $requestInsurance->id }}</td></tr>
+                            <tr><td>Priority</td><td>{{ $requestInsurance->priority }}</td></tr>
+                            <tr><td>Method</td><td class="font-bold">{{ mb_strtoupper($requestInsurance->method) }}</td></tr>
+                            <tr><td>Url (decoded)</td><td class="break-all">{{ urldecode($requestInsurance->url) }}</td></tr>
+                            <tr><td>Url</td><td class="break-all">{{ $requestInsurance->url }}</td></tr>
+                            <tr><td>Payload</td><td><x-request-insurance-pretty-print :content="$requestInsurance->getPayloadWithMaskingApplied()"/></td></tr>
+                            <tr><td>Headers</td><td><x-request-insurance-pretty-print :content="$requestInsurance->getHeadersWithMaskingApplied()"/></td></tr>
+                            <tr><td>Timings</td><td><x-request-insurance-pretty-print :content="$requestInsurance->timings"/></td></tr>
+                            <tr><td>Next attempt</td><td><x-request-insurance-timestamp :value="$requestInsurance->retry_at" /></td></tr>
+                            <tr><td>State changed</td><td><x-request-insurance-timestamp :value="$requestInsurance->state_changed_at" /></td></tr>
+                            <tr><td>Attempts</td><td>{{ $requestInsurance->retry_count }}</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
 
-                            <div class="row">
-                                <div class="col-6 mt-2">
-                                    <div class="card {{$edit->created_at->diffInSeconds(\Carbon\Carbon::now()) < 5 ? 'backgroundAnimated' : ''}}">
-                                        <div class="card-body">
-                                            <div class="card-title text-center">
-                                                <h3>
-                                                    Edit
-                                                    @if($edit->approvals()->count() < $edit->required_number_of_approvals)
-                                                        <div class="badge badge-primary">Pending</div>
+            {{-- Response --}}
+            <section aria-labelledby="response-heading" class="overflow-hidden rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+                <div class="border-b px-5 py-4 sm:px-6">
+                    <p class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.16em] text-slate-400">Inbound</p>
+                    <h2 id="response-heading" class="mt-1 text-lg font-extrabold text-slate-950 dark:text-white">Response</h2>
+                </div>
+                <div class="p-5 sm:p-6">
+                    <table class="kv w-full font-mono text-[13px]">
+                        <tbody>
+                            <tr><td>Code</td><td><x-request-insurance-http-code httpCode="{{ $requestInsurance->response_code }}"/></td></tr>
+                            <tr><td>Headers</td><td><x-request-insurance-pretty-print :content="$requestInsurance->response_headers"/></td></tr>
+                            <tr><td>Body</td><td><x-request-insurance-pretty-print :content="$requestInsurance->response_body"/></td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+
+        {{-- Edits --}}
+        @php $pendingEdits = $requestInsurance->edits()->where('applied_at', null)->orderBy('updated_at', 'DESC'); @endphp
+        @if($pendingEdits->count() > 0)
+            <details open class="group rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+                <summary class="flex cursor-pointer items-center gap-2 px-5 py-4 marker:content-none sm:px-6">
+                    <svg class="size-4 text-slate-400 transition group-open:rotate-90" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 4l4 4-4 4z"/></svg>
+                    <span class="text-lg font-extrabold text-slate-950 dark:text-white">Pending edits</span>
+                    <span class="rounded-full bg-slate-100 px-2.5 py-1 font-mono text-xs font-bold text-slate-600 dark:bg-slate-800 dark:text-slate-300">{{ $pendingEdits->count() }}</span>
+                </summary>
+                <div class="space-y-6 border-t p-5 sm:p-6">
+                    @foreach($pendingEdits->get() as $edit)
+                        @php
+                            $canModifyEdit = $edit->applied_at == null && $edit->admin_user == $user;
+                            $canApproveEdit = $edit->applied_at == null && ! $canModifyEdit;
+                            $canApplyEdit = $edit->applied_at == null && $edit->approvals->count() >= $edit->required_number_of_approvals && $canModifyEdit;
+                        @endphp
+                        <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                            {{-- Edit form --}}
+                            <div class="rounded-xl border bg-slate-50/60 dark:bg-slate-950/40 {{ $edit->created_at->diffInSeconds(\Carbon\Carbon::now()) < 5 ? 'backgroundAnimated' : '' }}">
+                                <div class="flex items-center justify-between border-b px-4 py-3">
+                                    <h3 class="font-extrabold text-slate-950 dark:text-white">Edit</h3>
+                                    @if($edit->approvals()->count() < $edit->required_number_of_approvals)
+                                        <span class="chip chip-primary">Pending approval</span>
+                                    @else
+                                        <span class="chip chip-success">Approved</span>
+                                    @endif
+                                </div>
+                                <div class="p-4">
+                                    <form method="POST" action="{{ route('request-insurance-edits.update', $edit) }}">@csrf
+                                        <table class="kv w-full font-mono text-[13px]">
+                                            <tbody>
+                                                <tr><td>Editor</td><td>{{ $edit->admin_user }}</td></tr>
+                                                <tr><td>Id</td><td>{{ $edit->request_insurance_id }}</td></tr>
+                                                <tr><td>Priority</td><td><input name="new_priority" type="number" min="0" max="9999" class="{{ $editInput }}"
+                                                    onchange="(()=>{this.value=this.value<0?0:this.value>9999?9999:this.value;})()"
+                                                    onkeyup="(()=>{this.value=this.value<0?0:this.value>9999?9999:this.value;})()"
+                                                    @disabled( ! $canModifyEdit) value="{{ $edit->new_priority }}"/></td></tr>
+                                                <tr><td>Method</td><td>
+                                                    <select name="new_method" class="{{ $editInput }}" @disabled( ! $canModifyEdit)>
+                                                        @foreach(['GET','POST','PUT','PATCH','DELETE'] as $m)
+                                                            <option value="{{ $m }}" @selected(mb_strtoupper($edit->new_method) == $m)>{{ $m }}</option>
+                                                        @endforeach
+                                                    </select></td></tr>
+                                                <tr><td>Url</td><td><input name="new_url" class="{{ $editInput }}" @disabled( ! $canModifyEdit) value="{{ urldecode($edit->new_url) }}"/></td></tr>
+                                                <tr><td>Payload</td><td>
+                                                    @if($canModifyEdit)
+                                                        <x-request-insurance-pretty-print-text-area :name='"new_payload"' :content="$edit->new_payload" :disabled=" ! $canModifyEdit"/>
                                                     @else
-                                                        <div class="badge badge-success">Approved</div>
+                                                        <x-request-insurance-pretty-print :content="$edit->new_payload"/>
                                                     @endif
-                                                </h3>
-                                                <hr>
-                                            </div>
-                                            <div class="card-text">
-                                                <form method="POST" action="{{ route('request-insurance-edits.update', $edit) }}">
-                                                    @csrf
-                                                    <table class="table-hover w-100 table-vertical table-striped">
-                                                        <tbody>
-                                                        <tr>
-                                                            <td>Editor:</td>
-                                                            <td>{{ $edit->admin_user }}</td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td>RequestInsurance Id:</td>
-                                                            <td>{{ $edit->request_insurance_id }}</td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td>Priority:</td>
-                                                            <td><input name="new_priority" class="w-100" type="number" min="0" max="9999"
-                                                                       onchange="(() => {this.value=this.value < 0 ? 0 : this.value > 9999 ? 9999 : this.value;})()"
-                                                                       onkeyup="(() => {this.value=this.value < 0 ? 0 : this.value > 9999 ? 9999 : this.value;})()"
-                                                                       @disabled( ! $canModifyEdit)
-                                                                       value="{{ $edit->new_priority }}"/></td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td>Method:</td>
-                                                            <td>
-                                                                <select name="new_method" @disabled( ! $canModifyEdit)>
-                                                                    <option value="GET" @selected(mb_strtoupper($edit->new_method) == "GET")>GET</option>
-                                                                    <option value="POST" @selected(mb_strtoupper($edit->new_method) == "POST")>POST</option>
-                                                                    <option value="PUT" @selected(mb_strtoupper($edit->new_method) == "PUT")>PUT</option>
-                                                                    <option value="PATCH" @selected(mb_strtoupper($edit->new_method) == "PATCH")>PATCH</option>
-                                                                    <option value="DELETE" @selected(mb_strtoupper($edit->new_method) == "DELETE")>DELETE</option>
-                                                                </select>
-                                                            </td>
-                                                        </tr>
-                                                        <tr class="w-100">
-                                                            <td>Url:</td>
-                                                            <td><input name="new_url" class="w-100"
-                                                                       @disabled( ! $canModifyEdit)
-                                                                       value="{{ urldecode($edit->new_url) }}"/></td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td>Payload:</td>
-                                                            <td style="max-width:1px"><!-- Makes the pretty printed code wrap lines -->
-                                                                @if($canModifyEdit)
-                                                                    <x-request-insurance-pretty-print-text-area :name='"new_payload"' :content="$edit->new_payload" :disabled=" ! $canModifyEdit"/>
-                                                                @else
-                                                                    <x-request-insurance-pretty-print :content="$edit->new_payload"/>
-                                                                @endif
-                                                            </td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td>Headers:</td>
-                                                            <td style="max-width:1px"><!-- Makes the pretty printed code wrap lines -->
-                                                                @if($canModifyEdit)
-                                                                    <x-request-insurance-pretty-print-text-area :name='"new_headers"' :content="$edit->new_headers" :disabled=" ! $canModifyEdit"/>
-                                                                @else
-                                                                    <x-request-insurance-pretty-print :content="$edit->new_headers"/>
-                                                                @endif
-                                                                @if( ! empty($errorMsg = getEditErrorMessage($edit->id, 'header')))
-                                                                    <span class="text-danger">{{$errorMsg}}</span>
-                                                                @endif
-                                                            </td>
-                                                        </tr>
-                                                        </tbody>
-                                                    </table>
-                                                    <div class="m-2">
-                                                        @if ( $canModifyEdit )
-                                                            <input type="hidden" name="_method" value="post">
-                                                            <button class="btn btn-primary" type="submit">Save</button>
-                                                        @endif
-                                                    </div>
-                                                </form>
-                                                <form method="POST" action="{{ route('request-insurance-edits.destroy', $edit) }}">
-                                                    @csrf
-                                                    <div class="m-2">
-                                                        @if ( $canModifyEdit )
-                                                            <input type="hidden" name="_method" value="delete">
-                                                            <button class="btn btn-danger" type="submit">Delete</button>
-                                                        @endif
-                                                    </div>
-                                                </form>
-                                            </div>
-                                        </div>
-                                        <div class="card-text">
-                                            <hr>
-                                            <h4>Approvals <x-request-insurance-edit-approvals-status :requestInsuranceEdit="$edit" /></h4>
-                                            <table class="table table-hover border bg-white">
-                                                <thead>
-                                                <tr>
-                                                    <th>Approver</th>
-                                                    <th style="width: 185px">Created at</th>
-                                                </tr>
-                                                </thead>
-                                                <tbody>
+                                                </td></tr>
+                                                <tr><td>Headers</td><td>
+                                                    @if($canModifyEdit)
+                                                        <x-request-insurance-pretty-print-text-area :name='"new_headers"' :content="$edit->new_headers" :disabled=" ! $canModifyEdit"/>
+                                                    @else
+                                                        <x-request-insurance-pretty-print :content="$edit->new_headers"/>
+                                                    @endif
+                                                    @if( ! empty($errorMsg = getEditErrorMessage($edit->id, 'header')))
+                                                        <span class="text-xs font-semibold text-red-600 dark:text-red-400">{{ $errorMsg }}</span>
+                                                    @endif
+                                                </td></tr>
+                                            </tbody>
+                                        </table>
+                                        @if($canModifyEdit)
+                                            <div class="mt-3"><input type="hidden" name="_method" value="post"><button class="{{ $btnPrimary }}" type="submit">Save</button></div>
+                                        @endif
+                                    </form>
+
+                                    <div class="mt-4 border-t pt-4">
+                                        <h4 class="mb-2 flex items-center gap-2 font-extrabold text-slate-950 dark:text-white">Approvals <x-request-insurance-edit-approvals-status :requestInsuranceEdit="$edit" /></h4>
+                                        <table class="w-full font-mono text-[13px]">
+                                            <thead><tr class="text-left text-[0.68rem] font-bold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400 [&>th]:pb-1.5"><th>Approver</th><th>Created</th></tr></thead>
+                                            <tbody class="divide-y">
                                                 @foreach($edit->approvals->sortBy('created_at') as $approval)
-                                                    <tr>
-                                                        <td>{{ $approval->approver_admin_user }}</td>
-                                                        <td>{{ $approval->created_at }}</td>
-                                                    </tr>
+                                                    <tr class="[&>td]:py-1.5"><td>{{ $approval->approver_admin_user }}</td><td class="text-slate-500 dark:text-slate-400"><x-request-insurance-timestamp :value="$approval->created_at" /></td></tr>
                                                 @endforeach
-                                                </tbody>
-                                            </table>
-                                            <hr>
-                                            <table>
-                                                <tr>
-                                                    <td>
-                                                        @if($canApproveEdit)
-                                                            @php
-                                                                $approvalsByUser = $edit->approvals()->where('approver_admin_user', $user);
-                                                            @endphp
-                                                            @if($approvalsByUser->count() == 0)
-                                                                <form class="ml-2" method="POST" action="{{ route('request-insurance-edit-approvals.create', $edit) }}">
-                                                                    @csrf
-                                                                    <input type="hidden" name="_method" value="post">
-                                                                    <button class="btn btn-primary" type="submit"
-                                                                            @disabled( ! $canApproveEdit)>Approve</button>
-                                                                </form>
-                                                            @else
-                                                                <form class="ml-2" method="POST" action="{{ route('request-insurance-edit-approvals.destroy', $approvalsByUser->first()) }}">
-                                                                    @csrf
-                                                                    <input type="hidden" name="_method" value="delete">
-                                                                    <button class="btn btn-secondary" type="submit">Remove approval</button>
-                                                                </form>
-                                                            @endif
-                                                        @endif
-                                                    </td>
-                                                    <td>
-                                                        @if($canModifyEdit)
-                                                            <form class="ml-2" method="POST" action="{{ route('request-insurances-edits.apply', $edit) }}">
-                                                                @csrf
-                                                                <input type="hidden" name="_method" value="post">
-                                                                <button class="btn btn-primary" type="submit"
-                                                                        @disabled( ! $canApplyEdit)>Apply</button>
-                                                                @if( ! empty($errorMsg = getEditErrorMessage($edit->id, 'approval')))
-                                                                    <span class="text-danger">{{$errorMsg}}</span>
-                                                                @endif
-                                                            </form>
-                                                        @endif
-                                                    </td>
-                                                </tr>
-                                            </table>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-6 mt-2">
-                                    <div class="card">'
-                                        <div class="card-body">
-                                            <div class="card-title text-center">
-                                                <h3>
-                                                    Edit differences
-                                                </h3>
-                                                <hr>
-                                            </div>
-                                            <div class="card-text">
-                                                <table class="table-hover w-100 table-vertical table-striped">
-                                                    <tbody>
-                                                    <tr>
-                                                        <td>Editor: </td>
-                                                        <td>{{ $edit->admin_user }}</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>RequestInsurance Id: </td>
-                                                        <td>{{ $edit->request_insurance_id }}</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Priority:</td>
-                                                        <td>
-                                                            <x-request-insurance-pretty-print-difference :oldValues="strval($edit->old_priority)" :newValues="strval($edit->new_priority)"/>
-                                                        </td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Method:</td>
-                                                        <td>
-                                                            <x-request-insurance-pretty-print-difference :oldValues="strtoupper($edit->old_method)" :newValues="strtoupper($edit->new_method)" />
-                                                        </td>
-                                                    </tr>
-                                                    <tr class="w-100">
-                                                        <td>Url:</td>
-                                                        <td>
-                                                            <x-request-insurance-pretty-print-difference :oldValues="$edit->old_url" :newValues="$edit->new_url"/>
-                                                        </td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Payload:</td>
-                                                        <td style="max-width:1px"><!-- Makes the pretty printed code wrap lines -->
-                                                            <x-request-insurance-pretty-print-difference :oldValues="$edit->old_payload" :newValues="$edit->new_payload" />
-                                                        </td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Headers:</td>
-                                                        <td style="max-width:1px"><!-- Makes the pretty printed code wrap lines -->
-                                                            <x-request-insurance-pretty-print-difference :oldValues="$edit->old_headers" :newValues="$edit->new_headers" />
-                                                        </td>
-                                                    </tr>
-                                                    </tbody>
-                                                </table>
-                                            </div>
+                                            </tbody>
+                                        </table>
+
+                                        <div class="mt-3 flex flex-wrap gap-2">
+                                            @if($canApproveEdit)
+                                                @php $approvalsByUser = $edit->approvals()->where('approver_admin_user', $user); @endphp
+                                                @if($approvalsByUser->count() == 0)
+                                                    <form method="POST" action="{{ route('request-insurance-edit-approvals.create', $edit) }}">@csrf
+                                                        <input type="hidden" name="_method" value="post">
+                                                        <button class="{{ $btnPrimary }}" type="submit" @disabled( ! $canApproveEdit)>Approve</button>
+                                                    </form>
+                                                @else
+                                                    <form method="POST" action="{{ route('request-insurance-edit-approvals.destroy', $approvalsByUser->first()) }}">@csrf
+                                                        <input type="hidden" name="_method" value="delete">
+                                                        <button class="{{ $btnGhost }}" type="submit">Remove approval</button>
+                                                    </form>
+                                                @endif
+                                            @endif
+                                            @if($canModifyEdit)
+                                                <form method="POST" action="{{ route('request-insurances-edits.apply', $edit) }}">@csrf
+                                                    <input type="hidden" name="_method" value="post">
+                                                    <button class="{{ $btnPrimary }}" type="submit" @disabled( ! $canApplyEdit)>Apply</button>
+                                                </form>
+                                                <form method="POST" action="{{ route('request-insurance-edits.destroy', $edit) }}">@csrf
+                                                    <input type="hidden" name="_method" value="delete">
+                                                    <button class="{{ $btnDanger }}" type="submit">Delete</button>
+                                                </form>
+                                                @if( ! empty($errorMsg = getEditErrorMessage($edit->id, 'approval')))
+                                                    <span class="self-center text-xs font-semibold text-red-600 dark:text-red-400">{{ $errorMsg }}</span>
+                                                @endif
+                                            @endif
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                        @endforeach
-                    </div>
+
+                            {{-- Differences --}}
+                            <div class="rounded-xl border bg-slate-50/60 dark:bg-slate-950/40">
+                                <div class="border-b px-4 py-3"><h3 class="font-extrabold text-slate-950 dark:text-white">Differences</h3></div>
+                                <div class="p-4">
+                                    <table class="kv w-full font-mono text-[13px]">
+                                        <tbody>
+                                            <tr><td>Editor</td><td>{{ $edit->admin_user }}</td></tr>
+                                            <tr><td>Id</td><td>{{ $edit->request_insurance_id }}</td></tr>
+                                            <tr><td>Priority</td><td><x-request-insurance-pretty-print-difference :oldValues="strval($edit->old_priority)" :newValues="strval($edit->new_priority)"/></td></tr>
+                                            <tr><td>Method</td><td><x-request-insurance-pretty-print-difference :oldValues="strtoupper($edit->old_method)" :newValues="strtoupper($edit->new_method)" /></td></tr>
+                                            <tr><td>Url</td><td><x-request-insurance-pretty-print-difference :oldValues="$edit->old_url" :newValues="$edit->new_url"/></td></tr>
+                                            <tr><td>Payload</td><td><x-request-insurance-pretty-print-difference :oldValues="$edit->old_payload" :newValues="$edit->new_payload" /></td></tr>
+                                            <tr><td>Headers</td><td><x-request-insurance-pretty-print-difference :oldValues="$edit->old_headers" :newValues="$edit->new_headers" /></td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </details>
+        @endif
+
+        {{-- Logs --}}
+        <section aria-labelledby="logs-heading" class="overflow-hidden rounded-2xl border bg-white shadow-sm shadow-slate-900/5 dark:bg-slate-900">
+            <div class="border-b px-5 py-4 sm:px-6">
+                <p class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.16em] text-slate-400">Attempt history</p>
+                <h2 id="logs-heading" class="mt-1 text-lg font-extrabold text-slate-950 dark:text-white">Logs</h2>
+            </div>
+            @if($requestInsurance->logs->isEmpty())
+                <div class="px-6 py-12 text-center">
+                    <p class="font-bold text-slate-900 dark:text-white">No attempts logged yet</p>
+                    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Each processing attempt will be recorded here.</p>
+                </div>
+            @else
+                <div class="overflow-x-auto">
+                    <table class="w-full min-w-[56rem] text-left text-sm">
+                        <thead class="border-b bg-slate-50 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-slate-500 dark:bg-slate-950/60 dark:text-slate-400">
+                            <tr>
+                                <th class="px-4 py-3.5">ID</th>
+                                <th class="px-4 py-3.5">Code</th>
+                                <th class="px-4 py-3.5">Response headers</th>
+                                <th class="px-4 py-3.5">Response body</th>
+                                <th class="px-4 py-3.5">Created</th>
+                                <th class="px-4 py-3.5 text-right">ms</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y font-mono">
+                            @foreach ($requestInsurance->logs->sortByDesc('created_at') as $log)
+                                <tr class="transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/50 [&>td]:px-4 [&>td]:py-2.5 [&>td]:align-top">
+                                    <td class="text-xs font-semibold text-slate-500 dark:text-slate-400">{{ $log->id }}</td>
+                                    <td><x-request-insurance-http-code httpCode="{{ $log->response_code }}" /></td>
+                                    <td class="max-w-[280px] truncate text-slate-500 dark:text-slate-400" title="{{ $log->response_headers }}">{{ $log->response_headers }}</td>
+                                    <td class="max-w-[280px] truncate text-slate-500 dark:text-slate-400" title="{{ $log->response_body }}">{{ $log->response_body }}</td>
+                                    <td class="whitespace-nowrap text-xs text-slate-500 dark:text-slate-400"><x-request-insurance-timestamp :value="$log->created_at" /></td>
+                                    <td class="text-right tabular-nums text-slate-500 dark:text-slate-400">{{ $log->getTotalTime() < 0 ? '·' : number_format($log->getTotalTime()) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
             @endif
-            <!-- Logs -->
-            <div class="col-12 mt-2">
-                <div class="card">
-                    <div class="card-body">
-                        <div class="card-title text-center">
-                            <h3>Logs:</h3>
-                            <hr>
-                        </div>
-                        <div class="card-text">
-                            <table class="table table-hover border bg-white">
-                                <thead>
-                                <tr>
-                                    <th>id</th>
-                                    <th>Response code</th>
-                                    <th>Response headers</th>
-                                    <th>Response body</th>
-                                    <th style="width: 185px">Created at</th>
-                                    <th style="width: 100px">Total time (ms) </th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                @foreach ($requestInsurance->logs->sortByDesc('created_at') as $log)
-                                    <tr>
-                                        <td>{{ $log->id }}</td>
-                                        <td><x-request-insurance-http-code httpCode="{{ $log->response_code }}" /></td>
-                                        <td><x-request-insurance-inline-print :content="$log->response_headers"/></td>
-                                        <td><x-request-insurance-inline-print :content="$log->response_body"/></td>
-                                        <td>{{ $log->created_at }}</td>
-                                        <td>{{$log->getTotalTime()}}</td>
-                                    </tr>
-                                @endforeach
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        </section>
     </div>
 @endsection

--- a/src/RequestInsurance/Controllers/RequestInsuranceController.php
+++ b/src/RequestInsurance/Controllers/RequestInsuranceController.php
@@ -33,14 +33,68 @@ class RequestInsuranceController extends Controller
         // Flash the request parameters, so we can redisplay the same filter parameters.
         $request->flash();
 
+        $perPage = (int) $request->input('per_page', 25);
+
+        if ( ! in_array($perPage, [25, 50, 100, 250, 500, 1000], true)) {
+            $perPage = 25;
+        }
+
+        // Cursor pagination keeps deep pages cheap: it seeks on the id index
+        // instead of scanning and discarding an ever-growing offset.
         $paginator = RequestInsurance::query()
             ->orderByDesc('id')
             ->filteredByRequest($request)
-            ->paginate(25);
+            ->cursorPaginate($perPage)
+            ->withQueryString();
 
         return view('request-insurance::index')->with([
             'requestInsurances' => $paginator,
+            'perPage'           => $perPage,
         ]);
+    }
+
+    /**
+     * Retries a batch of selected request insurances at once
+     *
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function retrySelected(Request $request)
+    {
+        $ids = array_values(array_filter(array_map('intval', (array) $request->input('ids', []))));
+
+        if ( ! empty($ids)) {
+            RequestInsurance::query()
+                ->whereIn('id', $ids)
+                ->get()
+                ->filter(fn (RequestInsurance $requestInsurance) => $requestInsurance->isRetryable())
+                ->each(fn (RequestInsurance $requestInsurance) => $requestInsurance->retryNow());
+        }
+
+        return redirect()->back();
+    }
+
+    /**
+     * Abandons a batch of selected request insurances at once
+     *
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function abandonSelected(Request $request)
+    {
+        $ids = array_values(array_filter(array_map('intval', (array) $request->input('ids', []))));
+
+        if ( ! empty($ids)) {
+            RequestInsurance::query()
+                ->whereIn('id', $ids)
+                ->get()
+                ->filter(fn (RequestInsurance $requestInsurance) => $requestInsurance->doesNotHaveState(State::COMPLETED) && $requestInsurance->doesNotHaveState(State::ABANDONED))
+                ->each(fn (RequestInsurance $requestInsurance) => $requestInsurance->abandon());
+        }
+
+        return redirect()->back();
     }
 
     /**

--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -626,16 +626,15 @@ class RequestInsurance extends SaveRetryingModel
         }
 
         try {
-            if ($request->has('from') && $request->get('from') != null) {
-                $from = Carbon::parse($request->get('from'));
-                $query = $query->whereDate('created_at', '>=', $from);
-                $query = $query->whereTime('created_at', '>=', $from);
+            // A single datetime comparison — filtering date and time-of-day as
+            // two independent predicates excludes e.g. an 08:00 row from a
+            // range starting the previous day at 14:30.
+            if ($request->filled('from')) {
+                $query = $query->where('created_at', '>=', Carbon::parse($request->get('from')));
             }
 
-            if ($request->has('to') && $request->get('to') != null) {
-                $to = Carbon::parse($request->get('to'));
-                $query = $query->whereDate('created_at', '<=', $to);
-                $query = $query->whereTime('created_at', '<=', $to);
+            if ($request->filled('to')) {
+                $query = $query->where('created_at', '<=', Carbon::parse($request->get('to')));
             }
         } catch (Exception $exception) {
             Log::notice('Failed parsing from or to date to Carbon instance in filter');

--- a/src/RequestInsurance/RequestInsuranceServiceProvider.php
+++ b/src/RequestInsurance/RequestInsuranceServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Cego\RequestInsurance\Contracts\HttpRequest;
 use Cego\RequestInsurance\ViewComponents\Status;
 use Cego\RequestInsurance\ViewComponents\HttpCode;
+use Cego\RequestInsurance\ViewComponents\Timestamp;
 use Cego\RequestInsurance\Providers\IdentityProvider;
 use Cego\RequestInsurance\ViewComponents\InlinePrint;
 use Cego\RequestInsurance\ViewComponents\PrettyPrint;
@@ -66,6 +67,7 @@ class RequestInsuranceServiceProvider extends ServiceProvider
             Status::class,
             EditApprovalsStatus::class,
             PrettyPrintTextArea::class,
+            Timestamp::class,
         ]);
 
         // To avoid a hard dependency on spatie/prometheus-laravel and keep non-laravel and 7.4 support.

--- a/src/RequestInsurance/ViewComponents/Timestamp.php
+++ b/src/RequestInsurance/ViewComponents/Timestamp.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Cego\RequestInsurance\ViewComponents;
+
+use Illuminate\View\View;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\Factory;
+
+class Timestamp extends Component
+{
+    /**
+     * The timestamp to render (or null).
+     *
+     * @var \Carbon\Carbon|\DateTimeInterface|null
+     */
+    public $value;
+
+    /**
+     * @param \Carbon\Carbon|\DateTimeInterface|null $value
+     */
+    public function __construct($value = null)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return Factory|View
+     */
+    public function render()
+    {
+        return view('request-insurance::components.timestamp');
+    }
+}

--- a/tests/Unit/WebUiSmokeTest.php
+++ b/tests/Unit/WebUiSmokeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Auth\GenericUser;
+use Cego\RequestInsurance\Enums\State;
+use Cego\RequestInsurance\Models\RequestInsurance;
+
+class WebUiSmokeTest extends TestCase
+{
+    private function authenticate(): void
+    {
+        $this->actingAs(new GenericUser(['id' => 1, 'name' => 'test-admin']));
+    }
+
+    public function test_index_page_renders(): void
+    {
+        RequestInsurance::factory(3)->create(['state' => State::READY]);
+
+        $this->get(route('request-insurances.index'))
+            ->assertOk()
+            ->assertSee('Request pipeline');
+    }
+
+    public function test_index_page_renders_with_filters_and_page_size(): void
+    {
+        RequestInsurance::factory(3)->create(['state' => State::READY]);
+
+        $this->get(route('request-insurances.index', ['per_page' => 50, 'url' => '%', State::READY => 'on']))
+            ->assertOk();
+    }
+
+    public function test_index_page_falls_back_to_default_page_size_for_invalid_per_page(): void
+    {
+        RequestInsurance::factory(1)->create(['state' => State::READY]);
+
+        $this->get(route('request-insurances.index', ['per_page' => 123]))
+            ->assertOk()
+            ->assertViewHas('perPage', 25);
+    }
+
+    public function test_show_page_renders(): void
+    {
+        $this->authenticate();
+        $requestInsurance = RequestInsurance::factory()->create(['state' => State::READY]);
+
+        $this->get(route('request-insurances.show', $requestInsurance))
+            ->assertOk()
+            ->assertSee('#' . $requestInsurance->id, false);
+    }
+
+    public function test_edit_history_page_renders(): void
+    {
+        $this->authenticate();
+        $requestInsurance = RequestInsurance::factory()->create(['state' => State::READY]);
+
+        $this->get(route('request-insurances.edit-history', $requestInsurance))
+            ->assertOk()
+            ->assertSee('Edit history');
+    }
+
+    public function test_retry_selected_readies_failed_requests(): void
+    {
+        $failed = RequestInsurance::factory()->create(['state' => State::FAILED]);
+        $completed = RequestInsurance::factory()->create(['state' => State::COMPLETED]);
+
+        $this->post(route('request-insurances.retry-selected'), ['ids' => [$failed->id, $completed->id]])
+            ->assertRedirect();
+
+        $this->assertSame(State::READY, $failed->fresh()->state);
+        $this->assertSame(State::COMPLETED, $completed->fresh()->state);
+    }
+
+    public function test_abandon_selected_abandons_active_requests(): void
+    {
+        $active = RequestInsurance::factory()->create(['state' => State::READY]);
+        $completed = RequestInsurance::factory()->create(['state' => State::COMPLETED]);
+
+        $this->post(route('request-insurances.abandon-selected'), ['ids' => [$active->id, $completed->id]])
+            ->assertRedirect();
+
+        $this->assertSame(State::ABANDONED, $active->fresh()->state);
+        $this->assertSame(State::COMPLETED, $completed->fresh()->state);
+    }
+}

--- a/tests/Unit/WebUiSmokeTest.php
+++ b/tests/Unit/WebUiSmokeTest.php
@@ -50,6 +50,26 @@ class WebUiSmokeTest extends TestCase
             ->assertSee('#' . $requestInsurance->id, false);
     }
 
+    public function test_index_filters_on_from_and_to_as_full_datetimes(): void
+    {
+        $old = RequestInsurance::factory()->create(['state' => State::READY, 'created_at' => '2026-07-18 15:00:00']);
+        // Time-of-day (08:00) earlier than the filter's (14:30) — must still
+        // match a from on an earlier date.
+        $recent = RequestInsurance::factory()->create(['state' => State::READY, 'created_at' => '2026-07-20 08:00:00']);
+
+        $ids = collect($this->get(route('request-insurances.index', ['from' => '2026-07-19T14:30']))
+            ->assertOk()->viewData('requestInsurances')->items())->pluck('id');
+
+        $this->assertTrue($ids->contains($recent->id));
+        $this->assertFalse($ids->contains($old->id));
+
+        $ids = collect($this->get(route('request-insurances.index', ['to' => '2026-07-19T14:30']))
+            ->assertOk()->viewData('requestInsurances')->items())->pluck('id');
+
+        $this->assertTrue($ids->contains($old->id));
+        $this->assertFalse($ids->contains($recent->id));
+    }
+
     public function test_show_page_renders_with_a_pending_edit(): void
     {
         $this->authenticate();

--- a/tests/Unit/WebUiSmokeTest.php
+++ b/tests/Unit/WebUiSmokeTest.php
@@ -50,6 +50,18 @@ class WebUiSmokeTest extends TestCase
             ->assertSee('#' . $requestInsurance->id, false);
     }
 
+    public function test_show_page_renders_with_a_pending_edit(): void
+    {
+        $this->authenticate();
+        $requestInsurance = RequestInsurance::factory()->create(['state' => State::FAILED]);
+
+        $this->post(route('request-insurance-edits.create', $requestInsurance))->assertRedirect();
+
+        $this->get(route('request-insurances.show', $requestInsurance))
+            ->assertOk()
+            ->assertSee('Pending edits');
+    }
+
     public function test_edit_history_page_renders(): void
     {
         $this->authenticate();


### PR DESCRIPTION
## Summary

Rebuilds the package's management views on Tailwind CSS v4 (buildless browser runtime, SRI-pinned from cdnjs) with automatic light/dark mode that follows the system preference — including live preference changes. Bootstrap and jQuery are removed. This extracts and adapts the web-UI portion of #162 so it can ship independently of the partitioning work.

## What changed

- **Index**: lifecycle flow strip (success path plus a divergent FAILED/ABANDONED branch) with per-state counts fetched asynchronously, filter bar with state chip toggles, cursor pagination with selectable page sizes (25–1000), and equal-width row actions (Retry / Unlock / Abandon / Inspect).
- **Bulk actions**: select rows (or the whole page) and *Retry selected* / *Abandon selected* with confirmation. Retry only touches retryable requests; abandon skips COMPLETED/ABANDONED rows.
- **Show / edit history**: redesigned request/response inspection with JSON highlighted by highlight.js in terminal-styled blocks, a theme-aware diff viewer for pending edits, and standardized timestamps (relative when recent, absolute on hover) via a new `Timestamp` view component.
- **Cursor pagination** replaces offset pagination on the index, so deep pages seek on the id index instead of scanning an ever-growing offset.
- The monitoring endpoints move from the `api` to the `web` middleware group so the dashboard's asynchronous count fetch runs in the dashboard's own session instead of being redirected to the login provider by SSO/forward-auth setups (where the cross-origin redirect is blocked by CORS).
- New `WebUiSmokeTest` covers page rendering, per-page validation, and both bulk endpoints.

Unlike #162, the single `request_insurances` table remains the only storage, COMPLETED is still counted in the lifecycle strip, and the Unlock action for stuck PENDING requests is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)