### PR TITLE
Uppercase the HTTP method before handing it to Guzzle

### DIFF
--- a/src/RequestInsurance/AsyncRequests/RequestPool.php
+++ b/src/RequestInsurance/AsyncRequests/RequestPool.php
@@ -76,7 +76,7 @@ class RequestPool
      */
     private function convertRequestToPromise(Client $client, RequestInsurance $requestInsurance): PromiseInterface
     {
-        return $client->requestAsync($requestInsurance->method, $requestInsurance->url, [
+        return $client->requestAsync(mb_strtoupper($requestInsurance->method), $requestInsurance->url, [
             'headers'     => array_merge($requestInsurance->getHeadersCastToArray(), ['User-Agent' => sprintf('RequestInsurance %s', Config::get('app.name', 'unknown'))]),
             'body'        => $requestInsurance->payload,
             'timeout'     => $requestInsurance->getEffectiveTimeout(),

--- a/tests/Unit/RequestPoolTest.php
+++ b/tests/Unit/RequestPoolTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Database\Eloquent\Collection;
+use Cego\RequestInsurance\Models\RequestInsurance;
+use Cego\RequestInsurance\AsyncRequests\RequestPool;
+
+class RequestPoolTest extends TestCase
+{
+    public function test_it_uppercases_a_lowercase_method(): void
+    {
+        $this->assertMethodGivenToClient('post', 'POST');
+    }
+
+    public function test_it_leaves_an_uppercase_method_untouched(): void
+    {
+        $this->assertMethodGivenToClient('PUT', 'PUT');
+    }
+
+    public function test_it_uppercases_a_mixed_case_method(): void
+    {
+        $this->assertMethodGivenToClient('DeLeTe', 'DELETE');
+    }
+
+    /**
+     * Asserts which HTTP method the pool hands to the Guzzle client for a stored method
+     *
+     * Guzzle 7 still uppercases the method itself, so this asserts on the client
+     * argument rather than on the outgoing request.
+     *
+     * @param string $storedMethod
+     * @param string $expectedMethod
+     *
+     * @return void
+     */
+    protected function assertMethodGivenToClient(string $storedMethod, string $expectedMethod): void
+    {
+        // Arrange
+        $requestInsurance = RequestInsurance::getBuilder()
+            ->url('https://test.lupinsdev.dk')
+            ->method($storedMethod)
+            ->create();
+
+        $client = new class () extends Client {
+            /** @var string[] */
+            public array $methods = [];
+
+            public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface
+            {
+                $this->methods[] = $method;
+
+                return new FulfilledPromise(new Response(200));
+            }
+        };
+
+        // Act
+        (new RequestPool($client, new Collection([$requestInsurance])))->getResponses();
+
+        // Assert
+        $this->assertSame([$expectedMethod], $client->methods);
+    }
+}


### PR DESCRIPTION
## What

`RequestPool` passed the stored `method` value straight into `Client::requestAsync()`. Guzzle 7.11 deprecates non-uppercase HTTP methods there, and Guzzle 8.0 will preserve the casing it is given instead of normalising it.

A request insurance stores whatever casing the producer supplied — `RequestInsuranceBuilder::method()` validates case-insensitively but persists the input as-is, and the model has no mutator on the column — so lowercase methods reached the pool untouched and every processed request emitted a deprecation notice.

## Why here

The synchronous path already normalises: `HttpRequest::setMethod()` calls `mb_strtoupper()`. The async pool was simply missing the same step, so this closes an inconsistency inside the package rather than adding new behaviour.

Normalising at the Guzzle boundary also covers rows that are already queued and any producer that writes the column directly, which a fix in a calling package would not.

## Notes

No behaviour change on Guzzle 7 — `Psr7\Request::__construct()` still calls `strtoupper()`, so the method put on the wire is the same today. This removes the deprecation notice and keeps the request correct once Guzzle 8 drops that normalisation.

Nothing in the package compares `method` case-sensitively, so mixed casing already stored in the table is unaffected.

The test asserts on the argument given to the client rather than on the outgoing request, precisely because Guzzle 7 masks the difference downstream.