### PR TITLE
1.x: run worker row reservation at READ COMMITTED and add opt-in reservation index pinning

### DIFF
--- a/publishable/config/request-insurance.php
+++ b/publishable/config/request-insurance.php
@@ -98,5 +98,9 @@ return [
     'table_edits'          => null,
     'table_edit_approvals' => null,
 
-    'useDbReconnect' => env('REQUEST_INSURANCE_WORKER_USE_DB_RECONNECT', true)
+    'useDbReconnect' => env('REQUEST_INSURANCE_WORKER_USE_DB_RECONNECT', true),
+
+    'useForceIndex' => env('REQUEST_INSURANCE_WORKER_USE_FORCE_INDEX', false),
+
+    'forceIndexName' => env('REQUEST_INSURANCE_WORKER_FORCE_INDEX_NAME')
 ];

--- a/src/RequestInsurance/Commands/UnlockBlockedRequestInsurances.php
+++ b/src/RequestInsurance/Commands/UnlockBlockedRequestInsurances.php
@@ -5,6 +5,7 @@ namespace Cego\RequestInsurance\Commands;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Cego\RequestInsurance\Enums\State;
+use Cego\RequestInsurance\TransactionIsolation;
 use Cego\RequestInsurance\Models\RequestInsurance;
 
 class UnlockBlockedRequestInsurances extends Command
@@ -30,6 +31,8 @@ class UnlockBlockedRequestInsurances extends Command
      */
     public function handle(): int
     {
+        TransactionIsolation::readCommittedForNextTransaction();
+
         RequestInsurance::query()
             ->where('state', State::PENDING)
             ->where('state_changed_at', '<', Carbon::now('UTC')->subMinutes(5))

--- a/src/RequestInsurance/RequestInsuranceWorker.php
+++ b/src/RequestInsurance/RequestInsuranceWorker.php
@@ -150,6 +150,8 @@ class RequestInsuranceWorker
      */
     protected function readyWaitingRequestInsurances(): void
     {
+        TransactionIsolation::readCommittedForNextTransaction();
+
         RequestInsurance::query()
             ->where('state', State::WAITING)
             ->where('retry_at', '<=', Carbon::now('UTC'))
@@ -276,6 +278,8 @@ class RequestInsuranceWorker
      */
     public function acquireLockOnRowsToProcess(): Collection
     {
+        TransactionIsolation::readCommittedForNextTransaction();
+
         return DB::transaction(function () {
             $requestIds = $this->getIdsOfReadyRequests();
 
@@ -309,10 +313,19 @@ class RequestInsuranceWorker
      */
     public function getIdsOfReadyRequests()
     {
-        return resolve(RequestInsurance::class)::query()
+        $model = resolve(RequestInsurance::class);
+
+        $builder = $model::query()
             ->select('id')
             ->readyToBeProcessed()
-            ->take(Config::get('request-insurance.batchSize'))
+            ->take(Config::get('request-insurance.batchSize'));
+
+        if (Config::get('request-insurance.useForceIndex', false) && $model->getConnection()->getDriverName() === 'mysql') {
+            $indexName = Config::get('request-insurance.forceIndexName') ?? sprintf('%s_state_priority_index', $model->getTable());
+            $builder->from(DB::raw(sprintf('`%s` FORCE INDEX (`%s`)', $model->getTable(), $indexName)));
+        }
+
+        return $builder
             ->lock('FOR UPDATE SKIP LOCKED')
             ->pluck('id');
     }

--- a/src/RequestInsurance/TransactionIsolation.php
+++ b/src/RequestInsurance/TransactionIsolation.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cego\RequestInsurance;
+
+use Cego\RequestInsurance\Models\RequestInsurance;
+
+class TransactionIsolation
+{
+    public static function readCommittedForNextTransaction(): void
+    {
+        $connection = resolve(RequestInsurance::class)->getConnection();
+
+        if ($connection->getDriverName() !== 'mysql') {
+            return;
+        }
+
+        if ($connection->transactionLevel() > 0) {
+            return;
+        }
+
+        $connection->statement('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+    }
+}


### PR DESCRIPTION
Backport of #168: under REPEATABLE READ the worker's FOR UPDATE reservation and the WAITING/PENDING sweeps take next-key locks on every row scanned — not just matched — so a filesort or wrong-index plan locks the entire backlog and convoys all writers; running them at READ COMMITTED (safe with binlog_format=ROW) caps locks to the rows actually returned.

Gotcha: unlike #168 the index pinning defaults OFF here, because the 1.x consumer (spilnu-dk) uses a custom table whose index is named `state_priority_index` — enable it there with REQUEST_INSURANCE_WORKER_USE_FORCE_INDEX=true and REQUEST_INSURANCE_WORKER_FORCE_INDEX_NAME=state_priority_index.