### PR TITLE
Reconnect the database after any failed worker cycle

### DIFF
--- a/src/RequestInsurance/RequestInsuranceWorker.php
+++ b/src/RequestInsurance/RequestInsuranceWorker.php
@@ -139,29 +139,29 @@ class RequestInsuranceWorker
      */
     protected function handleCycleFailure(Throwable $throwable): void
     {
-        if ( ! $this->wasCausedByLostConnection($throwable)) {
+        if ($this->wasCausedByLostConnection($throwable)) {
+            $this->consecutiveLostConnections++;
+
+            $message = sprintf(
+                'RequestInsurance Worker (#%s) lost its database connection during %s and is reconnecting (%d in a row)',
+                $this->runningHash,
+                $this->currentPhase,
+                $this->consecutiveLostConnections
+            );
+
+            if ($this->consecutiveLostConnections > self::QUIET_LOST_CONNECTION_RECOVERIES) {
+                Log::error($message, ['exception' => $throwable]);
+            } else {
+                Log::debug($message);
+            }
+        } else {
             $this->consecutiveLostConnections = 0;
 
             Log::error($throwable);
-
-            return;
         }
 
-        $this->consecutiveLostConnections++;
-
-        $message = sprintf(
-            'RequestInsurance Worker (#%s) lost its database connection during %s and is reconnecting (%d in a row)',
-            $this->runningHash,
-            $this->currentPhase,
-            $this->consecutiveLostConnections
-        );
-
-        if ($this->consecutiveLostConnections > self::QUIET_LOST_CONNECTION_RECOVERIES) {
-            Log::error($message, ['exception' => $throwable]);
-        } else {
-            Log::debug($message);
-        }
-
+        // The connection is given up on no matter what failed the cycle, since a failure can leave it in a
+        // state it never recovers from on its own, such as a transaction its driver still considers open.
         rescue(fn () => $this->reconnectToDatabase(), null, false);
     }
 

--- a/tests/Unit/RequestInsuranceWorkerTest.php
+++ b/tests/Unit/RequestInsuranceWorkerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Exception;
 use Throwable;
+use PDOException;
 use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Support\Facades\Log;
@@ -501,7 +502,20 @@ class RequestInsuranceWorkerTest extends TestCase
 
         $worker->exposeReportCycleFailure($throwable);
 
-        $this->assertSame(0, $worker->reconnects);
+        $this->assertSame(1, $worker->reconnects);
+    }
+
+    public function test_it_gives_up_on_a_connection_holding_a_stranded_transaction(): void
+    {
+        $worker = $this->getWorkerProbe();
+
+        Log::shouldReceive('error')->times(5);
+
+        foreach (range(1, 5) as $ignored) {
+            $worker->exposeReportCycleFailure(new PDOException('There is already an active transaction'));
+        }
+
+        $this->assertSame(5, $worker->reconnects);
     }
 
     /**


### PR DESCRIPTION
The worker only reconnected when a cycle failed because of a lost database connection. Any other failure left the connection in place, which is not always safe to do.

A transaction that is aborted by a connection dying mid-flight makes Laravel roll back, and that rollback fails too, because there is nothing left to talk to. `handleRollBackException()` then resets `transactions` to `0` while keeping the PDO instance, so the connection believes it has no transaction open, but the driver still believes it has: `rollBack()` only clears that flag when it succeeds, and it can never succeed again on a dead socket.

From there the connection is permanently unusable. `beginTransaction()` sees `transactions === 0`, `reconnectIfMissingConnection()` does nothing because the PDO instance is not null, and the driver rejects the `BEGIN` before it even reaches the network:

```
PDOException: There is already an active transaction
```

That message is not in the lost connection list, so the worker logged it and carried straight on to the next cycle with the same broken connection, failing every cycle at ~10 errors per second until the process was restarted by hand.

Giving up on the connection after any failed cycle covers this, and everything else where a failure leaves state behind that the connection cannot clear itself. The reconnect is cheap next to the 100 ms the worker already sleeps after a failed cycle, and the existing logging policy is unchanged: lost connections stay quiet until they start repeating, anything else is still reported in full.