### PR TITLE
Force the package's indexes on worker state queries

### DIFF
--- a/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
+++ b/src/RequestInsurance/Commands/FailOrReadyProcessingRequestInsurances.php
@@ -44,7 +44,9 @@ class FailOrReadyProcessingRequestInsurances extends Command
      */
     protected function unstuckProcessingRequestInsurances(): void
     {
-        RequestInsurance::query()->where('state', State::PROCESSING)
+        RequestInsurance::query()
+            ->forceIndex('request_insurances_state_priority_index')
+            ->where('state', State::PROCESSING)
             ->where('state_changed_at', '<', Carbon::now('UTC')->subMinutes(10))
             ->cursor()
             ->each(function (RequestInsurance $requestInsurance) {

--- a/src/RequestInsurance/Commands/UnlockBlockedRequestInsurances.php
+++ b/src/RequestInsurance/Commands/UnlockBlockedRequestInsurances.php
@@ -31,6 +31,7 @@ class UnlockBlockedRequestInsurances extends Command
     public function handle(): int
     {
         RequestInsurance::query()
+            ->forceIndex('request_insurances_state_priority_index')
             ->where('state', State::PENDING)
             ->where('state_changed_at', '<', Carbon::now('UTC')->subMinutes(5))
             ->update(['state' => State::READY, 'state_changed_at' => Carbon::now('UTC')]);

--- a/src/RequestInsurance/Models/RequestInsurance.php
+++ b/src/RequestInsurance/Models/RequestInsurance.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use GuzzleHttp\TransferStats;
 use Cego\RequestInsurance\Events;
 use Illuminate\Support\Enumerable;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Crypt;
@@ -578,6 +579,15 @@ class RequestInsurance extends SaveRetryingModel
     protected function usesEncryption(): bool
     {
         return $this->encrypted_fields != null;
+    }
+
+    public function scopeForceIndex(Builder $query, string $indexName)
+    {
+        if ($this->getConnection()->getDriverName() !== 'mysql') {
+            return $query;
+        }
+
+        return $query->from(DB::raw(sprintf('`%s` FORCE INDEX (`%s`)', $this->getTable(), $indexName)));
     }
 
     /**

--- a/src/RequestInsurance/RequestInsuranceWorker.php
+++ b/src/RequestInsurance/RequestInsuranceWorker.php
@@ -247,6 +247,7 @@ class RequestInsuranceWorker
     protected function readyWaitingRequestInsurances(): void
     {
         RequestInsurance::query()
+            ->forceIndex('covering_index')
             ->where('state', State::WAITING)
             ->where('retry_at', '<=', Carbon::now('UTC'))
             ->update(['state' => State::READY, 'state_changed_at' => Carbon::now('UTC'), 'retry_at' => null]);
@@ -425,6 +426,7 @@ class RequestInsuranceWorker
     public function getIdsOfReadyRequests()
     {
         $builder = resolve(RequestInsurance::class)::query()
+            ->forceIndex('request_insurances_state_priority_index')
             ->select('id')
             ->readyToBeProcessed()
             ->take(Config::get('request-insurance.batchSize'));


### PR DESCRIPTION
The MariaDB query planner sometimes picks a wrong index for the worker's state-based queries and locks far more rows than the query targets, so the reservation, WAITING/PENDING sweeps and stuck-PROCESSING scan now FORCE INDEX the package's matching indexes (mysql driver only).