### PR TITLE
Run worker claims at READ COMMITTED

### DIFF
--- a/src/RequestInsurance/RequestInsuranceWorker.php
+++ b/src/RequestInsurance/RequestInsuranceWorker.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Facades\Log;
 use Cego\RequestInsurance\Enums\State;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\DetectsLostConnections;
-use Illuminate\Database\DetectsConcurrencyErrors;
 use Cego\RequestInsurance\Models\RequestInsurance;
 use Cego\RequestInsurance\AsyncRequests\RequestInsuranceClient;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -22,7 +21,6 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 class RequestInsuranceWorker
 {
     use DetectsLostConnections;
-    use DetectsConcurrencyErrors;
 
     private const TIMEOUT_EXIT_CODE = 124;
 
@@ -378,7 +376,7 @@ class RequestInsuranceWorker
         }
 
         // Gets requests to process ordered by priority and id
-        return resolve(RequestInsurance::class)->newQuery()
+        return resolve(RequestInsurance::class)::query()
             ->whereIn('id', $requestIds)
             ->get()
             ->sortBy(['priority', 'id']);
@@ -393,11 +391,13 @@ class RequestInsuranceWorker
      */
     public function acquireLockOnRowsToProcess(): Collection
     {
-        $requestInsurance = resolve(RequestInsurance::class);
-        $connection = $requestInsurance->getConnection();
-        $maxAttempts = 5;
-        $claim = function () use ($requestInsurance) {
-            $requestIds = $this->getIdsOfReadyRequests($requestInsurance);
+        // Avoid gap locks while moving claimed rows between state ranges.
+        if (DB::getDriverName() === 'mysql' && DB::transactionLevel() === 0) {
+            DB::statement('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+        }
+
+        return DB::transaction(function () {
+            $requestIds = $this->getIdsOfReadyRequests();
 
             // Bail if no request are ready to be processed
             if ($requestIds->isEmpty()) {
@@ -407,7 +407,7 @@ class RequestInsuranceWorker
             // Mark the selected jobs as PENDING so other workers do not try to consume them
             $now = CarbonImmutable::now();
 
-            $locksWereObtained = $requestInsurance->newQuery()
+            $locksWereObtained = resolve(RequestInsurance::class)::query()
                 ->whereIn('id', $requestIds)
                 ->update([
                     'state'            => State::PENDING,
@@ -419,26 +419,7 @@ class RequestInsuranceWorker
             }
 
             return $requestIds;
-        };
-
-        if ($connection->transactionLevel() > 0 || ! in_array($connection->getDriverName(), ['mysql', 'mariadb'], true)) {
-            return $connection->transaction($claim, $maxAttempts);
-        }
-
-        // Avoid retaining gap locks while claimed rows move between state-index ranges.
-        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-            $connection->statement('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
-
-            try {
-                return $connection->transaction($claim);
-            } catch (Throwable $throwable) {
-                if ($attempt === $maxAttempts || ! $this->causedByConcurrencyError($throwable)) {
-                    throw $throwable;
-                }
-            }
-        }
-
-        throw new \LogicException('RequestInsurance claim transaction exhausted its attempts');
+        }, 5);
     }
 
     /**
@@ -446,9 +427,9 @@ class RequestInsuranceWorker
      *
      * @return mixed
      */
-    public function getIdsOfReadyRequests(?RequestInsurance $requestInsurance = null)
+    public function getIdsOfReadyRequests()
     {
-        $builder = ($requestInsurance ?? resolve(RequestInsurance::class))->newQuery()
+        $builder = resolve(RequestInsurance::class)::query()
             ->select('id')
             ->readyToBeProcessed()
             ->take(Config::get('request-insurance.batchSize'));

--- a/src/RequestInsurance/RequestInsuranceWorker.php
+++ b/src/RequestInsurance/RequestInsuranceWorker.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Log;
 use Cego\RequestInsurance\Enums\State;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\DetectsLostConnections;
+use Illuminate\Database\DetectsConcurrencyErrors;
 use Cego\RequestInsurance\Models\RequestInsurance;
 use Cego\RequestInsurance\AsyncRequests\RequestInsuranceClient;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 class RequestInsuranceWorker
 {
     use DetectsLostConnections;
+    use DetectsConcurrencyErrors;
 
     private const TIMEOUT_EXIT_CODE = 124;
 
@@ -376,7 +378,7 @@ class RequestInsuranceWorker
         }
 
         // Gets requests to process ordered by priority and id
-        return resolve(RequestInsurance::class)::query()
+        return resolve(RequestInsurance::class)->newQuery()
             ->whereIn('id', $requestIds)
             ->get()
             ->sortBy(['priority', 'id']);
@@ -391,8 +393,11 @@ class RequestInsuranceWorker
      */
     public function acquireLockOnRowsToProcess(): Collection
     {
-        return DB::transaction(function () {
-            $requestIds = $this->getIdsOfReadyRequests();
+        $requestInsurance = resolve(RequestInsurance::class);
+        $connection = $requestInsurance->getConnection();
+        $maxAttempts = 5;
+        $claim = function () use ($requestInsurance) {
+            $requestIds = $this->getIdsOfReadyRequests($requestInsurance);
 
             // Bail if no request are ready to be processed
             if ($requestIds->isEmpty()) {
@@ -402,7 +407,7 @@ class RequestInsuranceWorker
             // Mark the selected jobs as PENDING so other workers do not try to consume them
             $now = CarbonImmutable::now();
 
-            $locksWereObtained = resolve(RequestInsurance::class)::query()
+            $locksWereObtained = $requestInsurance->newQuery()
                 ->whereIn('id', $requestIds)
                 ->update([
                     'state'            => State::PENDING,
@@ -414,7 +419,26 @@ class RequestInsuranceWorker
             }
 
             return $requestIds;
-        }, 5);
+        };
+
+        if ($connection->transactionLevel() > 0 || ! in_array($connection->getDriverName(), ['mysql', 'mariadb'], true)) {
+            return $connection->transaction($claim, $maxAttempts);
+        }
+
+        // Avoid retaining gap locks while claimed rows move between state-index ranges.
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            $connection->statement('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+
+            try {
+                return $connection->transaction($claim);
+            } catch (Throwable $throwable) {
+                if ($attempt === $maxAttempts || ! $this->causedByConcurrencyError($throwable)) {
+                    throw $throwable;
+                }
+            }
+        }
+
+        throw new \LogicException('RequestInsurance claim transaction exhausted its attempts');
     }
 
     /**
@@ -422,9 +446,9 @@ class RequestInsuranceWorker
      *
      * @return mixed
      */
-    public function getIdsOfReadyRequests()
+    public function getIdsOfReadyRequests(?RequestInsurance $requestInsurance = null)
     {
-        $builder = resolve(RequestInsurance::class)::query()
+        $builder = ($requestInsurance ?? resolve(RequestInsurance::class))->newQuery()
             ->select('id')
             ->readyToBeProcessed()
             ->take(Config::get('request-insurance.batchSize'));

--- a/tests/Unit/RequestInsuranceWorkerTest.php
+++ b/tests/Unit/RequestInsuranceWorkerTest.php
@@ -2,17 +2,20 @@
 
 namespace Tests\Unit;
 
+use Closure;
 use Exception;
 use Throwable;
 use PDOException;
 use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Event;
 use Cego\RequestInsurance\Enums\State;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Database\SQLiteConnection;
 use GuzzleHttp\Exception\ConnectException;
 use Cego\RequestInsurance\Events\RequestFailed;
 use Cego\RequestInsurance\RequestInsuranceWorker;
@@ -177,6 +180,75 @@ class RequestInsuranceWorkerTest extends TestCase
         $requestInsurance2->refresh();
 
         $this->assertCount(1, RequestInsurance::query()->where('state', '!=', State::COMPLETED)->get());
+    }
+
+    public function test_claiming_uses_read_committed_on_the_model_connection_for_mysql(): void
+    {
+        $connection = $this->registerWorkerConnection('mysql');
+        $model = $this->getModelForConnection($connection);
+        $requestId = $this->insertReadyRequest($connection);
+        $defaultTransactionLevel = DB::connection()->transactionLevel();
+        $this->assertSame($connection, $model->getConnection());
+        $this->app->instance(RequestInsurance::class, $model);
+
+        $requestIds = (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
+
+        $this->assertSame([$requestId], $requestIds->all());
+        $this->assertSame([1], $connection->transactionArguments);
+        $this->assertSame([
+            'SET TRANSACTION ISOLATION LEVEL READ COMMITTED',
+        ], $connection->statements);
+        $this->assertSame($defaultTransactionLevel, DB::connection()->transactionLevel());
+        $this->assertSame(0, $connection->transactionLevel());
+        $this->assertSame(State::PENDING, $model->newQuery()->find($requestId)->state);
+    }
+
+    public function test_claiming_reapplies_read_committed_after_a_concurrency_retry(): void
+    {
+        $connection = $this->registerWorkerConnection('mysql');
+        $connection->failFirstTransaction = true;
+        $model = $this->getModelForConnection($connection);
+        $requestId = $this->insertReadyRequest($connection);
+        $this->app->instance(RequestInsurance::class, $model);
+
+        $requestIds = (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
+
+        $this->assertSame([$requestId], $requestIds->all());
+        $this->assertSame([1, 1], $connection->transactionArguments);
+        $this->assertSame([
+            'SET TRANSACTION ISOLATION LEVEL READ COMMITTED',
+            'SET TRANSACTION ISOLATION LEVEL READ COMMITTED',
+        ], $connection->statements);
+    }
+
+    public function test_claiming_does_not_change_isolation_for_sqlite(): void
+    {
+        $connection = $this->registerWorkerConnection('sqlite');
+        $model = $this->getModelForConnection($connection);
+        $requestId = $this->insertReadyRequest($connection);
+        $this->app->instance(RequestInsurance::class, $model);
+
+        (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
+
+        $this->assertSame([], $connection->statements);
+        $this->assertSame([5], $connection->transactionArguments);
+        $this->assertSame(State::PENDING, $model->newQuery()->find($requestId)->state);
+    }
+
+    public function test_claiming_does_not_set_isolation_inside_an_existing_transaction(): void
+    {
+        $connection = $this->registerWorkerConnection('mysql');
+        $model = $this->getModelForConnection($connection);
+        $this->insertReadyRequest($connection);
+        $this->app->instance(RequestInsurance::class, $model);
+        $connection->beginTransaction();
+
+        (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
+
+        $this->assertSame([], $connection->statements);
+        $this->assertSame(1, $connection->transactionLevel());
+
+        $connection->rollBack();
     }
 
     public function test_it_pauses_requests_with_listeners_that_throw_exceptions_when_the_response_is_not_200(): void
@@ -546,5 +618,84 @@ class RequestInsuranceWorkerTest extends TestCase
                 $this->reconnects++;
             }
         };
+    }
+
+    private function registerWorkerConnection(string $driver): SQLiteConnection
+    {
+        $connection = new class (
+            new \PDO('sqlite:file:worker-test-' . uniqid('', true) . '?mode=memory&cache=shared'),
+            'worker-test',
+            '',
+            ['driver' => $driver, 'name' => 'worker-test']
+        ) extends SQLiteConnection {
+            public array $statements = [];
+
+            public array $transactionArguments = [];
+
+            public bool $failFirstTransaction = false;
+
+            public function statement($query, $bindings = [])
+            {
+                if ($query === 'SET TRANSACTION ISOLATION LEVEL READ COMMITTED') {
+                    $this->statements[] = $query;
+
+                    return true;
+                }
+
+                return parent::statement($query, $bindings);
+            }
+
+            public function transaction(Closure $callback, $attempts = 1)
+            {
+                $this->transactionArguments[] = $attempts;
+
+                if ($this->failFirstTransaction && count($this->transactionArguments) === 1) {
+                    throw new PDOException('Deadlock found when trying to get lock');
+                }
+
+                return parent::transaction($callback, $attempts);
+            }
+        };
+
+        $connection->getSchemaBuilder()->create('request_insurances', function ($table): void {
+            $table->increments('id');
+            $table->unsignedInteger('priority');
+            $table->string('state');
+            $table->timestamp('retry_at')->nullable();
+            $table->timestamp('state_changed_at')->nullable();
+            $table->timestamp('updated_at')->nullable();
+        });
+
+        return $connection;
+    }
+
+    private function getModelForConnection(SQLiteConnection $connection): RequestInsurance
+    {
+        $model = new class () extends RequestInsurance {
+            public static SQLiteConnection $workerConnection;
+
+            public function getConnection()
+            {
+                return static::$workerConnection;
+            }
+
+            public function getTable(): string
+            {
+                return 'request_insurances';
+            }
+        };
+
+        $model::$workerConnection = $connection;
+
+        return $model;
+    }
+
+    private function insertReadyRequest(SQLiteConnection $connection): int
+    {
+        return $connection->table('request_insurances')->insertGetId([
+            'priority'         => 0,
+            'state'            => State::READY,
+            'state_changed_at' => now(),
+        ]);
     }
 }

--- a/tests/Unit/RequestInsuranceWorkerTest.php
+++ b/tests/Unit/RequestInsuranceWorkerTest.php
@@ -2,20 +2,17 @@
 
 namespace Tests\Unit;
 
-use Closure;
 use Exception;
 use Throwable;
 use PDOException;
 use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Event;
 use Cego\RequestInsurance\Enums\State;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Database\SQLiteConnection;
 use GuzzleHttp\Exception\ConnectException;
 use Cego\RequestInsurance\Events\RequestFailed;
 use Cego\RequestInsurance\RequestInsuranceWorker;
@@ -180,75 +177,6 @@ class RequestInsuranceWorkerTest extends TestCase
         $requestInsurance2->refresh();
 
         $this->assertCount(1, RequestInsurance::query()->where('state', '!=', State::COMPLETED)->get());
-    }
-
-    public function test_claiming_uses_read_committed_on_the_model_connection_for_mysql(): void
-    {
-        $connection = $this->registerWorkerConnection('mysql');
-        $model = $this->getModelForConnection($connection);
-        $requestId = $this->insertReadyRequest($connection);
-        $defaultTransactionLevel = DB::connection()->transactionLevel();
-        $this->assertSame($connection, $model->getConnection());
-        $this->app->instance(RequestInsurance::class, $model);
-
-        $requestIds = (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
-
-        $this->assertSame([$requestId], $requestIds->all());
-        $this->assertSame([1], $connection->transactionArguments);
-        $this->assertSame([
-            'SET TRANSACTION ISOLATION LEVEL READ COMMITTED',
-        ], $connection->statements);
-        $this->assertSame($defaultTransactionLevel, DB::connection()->transactionLevel());
-        $this->assertSame(0, $connection->transactionLevel());
-        $this->assertSame(State::PENDING, $model->newQuery()->find($requestId)->state);
-    }
-
-    public function test_claiming_reapplies_read_committed_after_a_concurrency_retry(): void
-    {
-        $connection = $this->registerWorkerConnection('mysql');
-        $connection->failFirstTransaction = true;
-        $model = $this->getModelForConnection($connection);
-        $requestId = $this->insertReadyRequest($connection);
-        $this->app->instance(RequestInsurance::class, $model);
-
-        $requestIds = (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
-
-        $this->assertSame([$requestId], $requestIds->all());
-        $this->assertSame([1, 1], $connection->transactionArguments);
-        $this->assertSame([
-            'SET TRANSACTION ISOLATION LEVEL READ COMMITTED',
-            'SET TRANSACTION ISOLATION LEVEL READ COMMITTED',
-        ], $connection->statements);
-    }
-
-    public function test_claiming_does_not_change_isolation_for_sqlite(): void
-    {
-        $connection = $this->registerWorkerConnection('sqlite');
-        $model = $this->getModelForConnection($connection);
-        $requestId = $this->insertReadyRequest($connection);
-        $this->app->instance(RequestInsurance::class, $model);
-
-        (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
-
-        $this->assertSame([], $connection->statements);
-        $this->assertSame([5], $connection->transactionArguments);
-        $this->assertSame(State::PENDING, $model->newQuery()->find($requestId)->state);
-    }
-
-    public function test_claiming_does_not_set_isolation_inside_an_existing_transaction(): void
-    {
-        $connection = $this->registerWorkerConnection('mysql');
-        $model = $this->getModelForConnection($connection);
-        $this->insertReadyRequest($connection);
-        $this->app->instance(RequestInsurance::class, $model);
-        $connection->beginTransaction();
-
-        (new RequestInsuranceWorker())->acquireLockOnRowsToProcess();
-
-        $this->assertSame([], $connection->statements);
-        $this->assertSame(1, $connection->transactionLevel());
-
-        $connection->rollBack();
     }
 
     public function test_it_pauses_requests_with_listeners_that_throw_exceptions_when_the_response_is_not_200(): void
@@ -618,84 +546,5 @@ class RequestInsuranceWorkerTest extends TestCase
                 $this->reconnects++;
             }
         };
-    }
-
-    private function registerWorkerConnection(string $driver): SQLiteConnection
-    {
-        $connection = new class (
-            new \PDO('sqlite:file:worker-test-' . uniqid('', true) . '?mode=memory&cache=shared'),
-            'worker-test',
-            '',
-            ['driver' => $driver, 'name' => 'worker-test']
-        ) extends SQLiteConnection {
-            public array $statements = [];
-
-            public array $transactionArguments = [];
-
-            public bool $failFirstTransaction = false;
-
-            public function statement($query, $bindings = [])
-            {
-                if ($query === 'SET TRANSACTION ISOLATION LEVEL READ COMMITTED') {
-                    $this->statements[] = $query;
-
-                    return true;
-                }
-
-                return parent::statement($query, $bindings);
-            }
-
-            public function transaction(Closure $callback, $attempts = 1)
-            {
-                $this->transactionArguments[] = $attempts;
-
-                if ($this->failFirstTransaction && count($this->transactionArguments) === 1) {
-                    throw new PDOException('Deadlock found when trying to get lock');
-                }
-
-                return parent::transaction($callback, $attempts);
-            }
-        };
-
-        $connection->getSchemaBuilder()->create('request_insurances', function ($table): void {
-            $table->increments('id');
-            $table->unsignedInteger('priority');
-            $table->string('state');
-            $table->timestamp('retry_at')->nullable();
-            $table->timestamp('state_changed_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
-        });
-
-        return $connection;
-    }
-
-    private function getModelForConnection(SQLiteConnection $connection): RequestInsurance
-    {
-        $model = new class () extends RequestInsurance {
-            public static SQLiteConnection $workerConnection;
-
-            public function getConnection()
-            {
-                return static::$workerConnection;
-            }
-
-            public function getTable(): string
-            {
-                return 'request_insurances';
-            }
-        };
-
-        $model::$workerConnection = $connection;
-
-        return $model;
-    }
-
-    private function insertReadyRequest(SQLiteConnection $connection): int
-    {
-        return $connection->table('request_insurances')->insertGetId([
-            'priority'         => 0,
-            'state'            => State::READY,
-            'state_changed_at' => now(),
-        ]);
     }
 }


### PR DESCRIPTION
## Summary

- run the next top-level MySQL worker claim transaction at `READ COMMITTED` to avoid retaining gap locks while rows move between state ranges
- leave the existing claim query and transaction retry flow unchanged